### PR TITLE
quick fix for nexus tests

### DIFF
--- a/tests/actions/nexus-mutual/nexus-mutual.test.ts
+++ b/tests/actions/nexus-mutual/nexus-mutual.test.ts
@@ -54,7 +54,16 @@ describe('BuyCover tests', () => {
       );
     }
 
-    const { buyCoverParams, poolAllocationRequests } = response.result.buyCoverInput;
+    let { buyCoverParams, poolAllocationRequests } = response.result.buyCoverInput;
+
+    /// THE NEXUS SDK SOMETIMES RETURNS A PREMIUM THAT IS TOO LOW
+    /// THIS IS A HACK TO MAKE IT HIGHER JUST FOR OUR TESTS
+    /// This only seems necessary when we aren't using ETH as the cover asset
+    if (coverAsset !== CoverAsset.ETH) {
+      buyCoverParams.maxPremiumInAsset = (
+        BigInt(buyCoverParams.maxPremiumInAsset) * BigInt(2)
+      ).toString();
+    }
 
     const abiCoder = new ethers.AbiCoder();
     const buyCoverParamsEncoded = abiCoder.encode(


### PR DESCRIPTION
A hacky fix to increase the max amount we're willing to pay for insurance. This is to prevent our tests failing from bad information provided by the nexus SDK