### PR TITLE
DEL-235 Implement LogType enum

### DIFF
--- a/contracts/Logger.sol
+++ b/contracts/Logger.sol
@@ -2,15 +2,15 @@
 
 pragma solidity =0.8.24;
 
-contract Logger {
-    event ActionEvent(address caller, uint256 logId, bytes data);
-    event AdminVaultEvent(uint256 logId, bytes data);
+import {ActionBase} from "./actions/ActionBase.sol";
+import {ILogger} from "./interfaces/ILogger.sol";
 
+contract Logger is ILogger {
     /// @notice Logs an event from an action
-    /// @param _logId The ID of the log
+    /// @param _logType The type of the log
     /// @param _data The data to log
-    function logActionEvent(uint256 _logId, bytes memory _data) public {
-        emit ActionEvent(msg.sender, _logId, _data);
+    function logActionEvent(ActionBase.LogType _logType, bytes memory _data) public {
+        emit ActionEvent(msg.sender, _logType, _data);
     }
 
     /// @notice Logs an event from the AdminVault

--- a/contracts/actions/ActionBase.sol
+++ b/contracts/actions/ActionBase.sol
@@ -36,6 +36,19 @@ abstract contract ActionBase {
         CUSTOM_ACTION
     }
 
+    /// @notice Enum representing different types of logs
+    // List of log types, this list should be updated with each new log type added to the system.
+    //   Existing values should not be changed/removed, as they may be already in use by a deployed action.
+    //   UNUSED keeps the enum starting at index 1 for off-chain processing.
+    enum LogType {
+        UNUSED,
+        BALANCE_UPDATE,
+        BUY_COVER,
+        CURVE_3POOL_SWAP,
+        SEND_TOKEN,
+        PULL_TOKEN
+    }
+
     /// @notice Initializes the ActionBase contract
     /// @param _adminVault Address of the admin vault
     /// @param _logger Address of the logger contract

--- a/contracts/actions/aave-v2/AaveV2Supply.sol
+++ b/contracts/actions/aave-v2/AaveV2Supply.sol
@@ -55,7 +55,7 @@ contract AaveV2Supply is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.assetId, balanceBefore, balanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/aave-v2/AaveV2Withdraw.sol
+++ b/contracts/actions/aave-v2/AaveV2Withdraw.sol
@@ -51,7 +51,7 @@ contract AaveV2Withdraw is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.assetId, balanceBefore, balanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/aave-v3/AaveV3Supply.sol
+++ b/contracts/actions/aave-v3/AaveV3Supply.sol
@@ -57,7 +57,7 @@ contract AaveV3Supply is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.assetId, balanceBefore, balanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/aave-v3/AaveV3Withdraw.sol
+++ b/contracts/actions/aave-v3/AaveV3Withdraw.sol
@@ -48,7 +48,7 @@ contract AaveV3Withdraw is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.assetId, balanceBefore, balanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/fluid/FluidSupply.sol
+++ b/contracts/actions/fluid/FluidSupply.sol
@@ -47,7 +47,7 @@ contract FluidSupply is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.poolId, fBalanceBefore, fBalanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/fluid/FluidWithdraw.sol
+++ b/contracts/actions/fluid/FluidWithdraw.sol
@@ -40,7 +40,7 @@ contract FluidWithdraw is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.poolId, fBalanceBefore, fBalanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/nexus-mutual/BuyCover.sol
+++ b/contracts/actions/nexus-mutual/BuyCover.sol
@@ -55,7 +55,7 @@ contract BuyCover is ActionBase {
         (uint32 period, uint256 amount, uint256 coverId) = _buyCover(inputData);
 
         // Log event
-        LOGGER.logActionEvent(2, _encodeBuyCover(_strategyId, period, amount, coverId));
+        LOGGER.logActionEvent(LogType.BUY_COVER, _encodeBuyCover(_strategyId, period, amount, coverId));
     }
 
     /// @inheritdoc ActionBase

--- a/contracts/actions/swap/Curve3PoolSwap.sol
+++ b/contracts/actions/swap/Curve3PoolSwap.sol
@@ -75,7 +75,7 @@ contract Curve3PoolSwap is ActionBase {
         uint256 balanceAfter = tokenOut.balanceOf(address(this));
         uint256 amountOut = balanceAfter - balanceBefore;
 
-        LOGGER.logActionEvent(3, abi.encode(_params, amountOut));
+        LOGGER.logActionEvent(LogType.CURVE_3POOL_SWAP, abi.encode(_params, amountOut));
     }
 
     /// @notice Parses the input data from bytes to Params struct

--- a/contracts/actions/utils/PullToken.sol
+++ b/contracts/actions/utils/PullToken.sol
@@ -27,7 +27,7 @@ contract PullToken is ActionBase {
         _pullToken(inputData.tokenAddr, inputData.from, inputData.amount);
 
         // Log event
-        LOGGER.logActionEvent(5, abi.encode(inputData.tokenAddr, inputData.from, inputData.amount));
+        LOGGER.logActionEvent(LogType.PULL_TOKEN, abi.encode(inputData.tokenAddr, inputData.from, inputData.amount));
     }
 
     /// @inheritdoc ActionBase

--- a/contracts/actions/utils/SendToken.sol
+++ b/contracts/actions/utils/SendToken.sol
@@ -33,10 +33,7 @@ contract SendToken is ActionBase {
         _sendToken(inputData.tokenAddr, inputData.to, inputData.amount);
 
         // Log event
-        LOGGER.logActionEvent(
-            4,
-            abi.encode(inputData.tokenAddr, inputData.to, inputData.amount)
-        );
+        LOGGER.logActionEvent(LogType.SEND_TOKEN, abi.encode(inputData.tokenAddr, inputData.to, inputData.amount));
     }
 
     /// @inheritdoc ActionBase

--- a/contracts/actions/yearn/YearnSupply.sol
+++ b/contracts/actions/yearn/YearnSupply.sol
@@ -47,7 +47,7 @@ contract YearnSupply is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.poolId, yBalanceBefore, yBalanceAfter, feeInTokens)
         );
     }

--- a/contracts/actions/yearn/YearnWithdraw.sol
+++ b/contracts/actions/yearn/YearnWithdraw.sol
@@ -40,7 +40,7 @@ contract YearnWithdraw is ActionBase {
 
         // Log event
         LOGGER.logActionEvent(
-            1,
+            LogType.BALANCE_UPDATE,
             _encodeBalanceUpdate(_strategyId, inputData.poolId, yBalanceBefore, yBalanceAfter, feeInTokens)
         );
     }

--- a/contracts/interfaces/ILogger.sol
+++ b/contracts/interfaces/ILogger.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.24;
 
-interface ILogger {
-    event ActionEvent(address indexed caller, uint256 indexed logId, bytes data);
-    event AdminVaultEvent(uint256 indexed logId, bytes data);
+import {ActionBase} from "../actions/ActionBase.sol";
 
-    function logActionEvent(uint256 _logId, bytes memory _data) external;
+interface ILogger {
+    event ActionEvent(address caller, ActionBase.LogType logId, bytes data);
+    event AdminVaultEvent(uint256 logId, bytes data);
+
+    function logActionEvent(ActionBase.LogType _logType, bytes memory _data) external;
     function logAdminVaultEvent(uint256 _logId, bytes memory _data) external;
 }

--- a/tests/logs.ts
+++ b/tests/logs.ts
@@ -8,7 +8,7 @@
 //     - The decode function should take in the baseLog and the decodedBytes and return the log
 
 export const LOGGER_INTERFACE = [
-  'event ActionEvent(address caller, uint256 logId, bytes data)',
+  'event ActionEvent(address caller, uint8 logId, bytes data)',
   'event AdminVaultEvent(string logName, bytes data)',
 ];
 


### PR DESCRIPTION
All actions (and the Logger) now reference the LogType enum in ActionBase.
The Logger interface was outdated and still had indexed events, so now Logger implements it's own interface, this will prevent a mismatch between the interface and the contract in the future.