### PR TITLE
fix Aave tests

### DIFF
--- a/tests/actions/aave-v2/AaveV2.test.ts
+++ b/tests/actions/aave-v2/AaveV2.test.ts
@@ -356,7 +356,8 @@ describe('Aave V2 tests', () => {
       await fundAccountWithToken(safeAddr, token, amount);
 
       const aUSDC = await ethers.getContractAt('IERC20', tokenConfig.aUSDC_V2.address);
-      const feeRecipient = await adminVault.feeRecipient();
+      const feeConfig = await adminVault.feeConfig();
+      const feeRecipient = feeConfig.recipient;
       const feeRecipientaUSDCBalanceBefore = await aUSDC.balanceOf(feeRecipient);
 
       const supplyTx = await executeAction({

--- a/tests/actions/aave-v3/AaveV3.test.ts
+++ b/tests/actions/aave-v3/AaveV3.test.ts
@@ -349,7 +349,8 @@ describe('Aave V3 tests', () => {
       await fundAccountWithToken(safeAddr, token, amount);
 
       const aUSDC_V3 = await ethers.getContractAt('IERC20', tokenConfig.aUSDC_V3.address);
-      const feeRecipient = await adminVault.feeRecipient();
+      const feeConfig = await adminVault.feeConfig();
+      const feeRecipient = feeConfig.recipient;
       const feeRecipientaUSDC_V3BalanceBefore = await aUSDC_V3.balanceOf(feeRecipient);
 
       const supplyTx = await executeAction({


### PR DESCRIPTION
The Aave Actions were merged at the same time as the feeConfig update and the CI didn't re-run the tests. This updates the Aave tests to match the changes made to feeConfig