### PR TITLE
fix tenderly errors

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,10 +5,6 @@ import * as tenderly from '@tenderly/hardhat-tenderly';
 import 'dotenv/config';
 import { HardhatUserConfig } from 'hardhat/config';
 
-tenderly.setup({
-  automaticVerifications: !!process.env.TENDERLY_AUTOMATIC_VERIFICATION,
-});
-
 const config: HardhatUserConfig = {
   solidity: '0.8.24',
   paths: {


### PR DESCRIPTION
Tenderly apparently no longer requires setting up auto verification, keeping this in was giving many errors while running tests.
We should look into their privateVerification if we need it:[https://docs.tenderly.co/contract-verification/hardhat]( https://docs.tenderly.co/contract-verification/hardhat)