### PR TITLE
implement Notional V3

### DIFF
--- a/contracts/actions/common/ERC4626Supply.sol
+++ b/contracts/actions/common/ERC4626Supply.sol
@@ -79,7 +79,7 @@ abstract contract ERC4626Supply is ActionBase {
             require(amountToDeposit != 0, Errors.Action_ZeroAmount(protocolName(), uint8(actionType())));
 
             // Perform the deposit
-            underlyingToken.safeIncreaseAllowance(_vaultAddress, amountToDeposit);
+            _increaseAllowance(address(underlyingToken), _vaultAddress, amountToDeposit);
             uint256 shares = _deposit(_vaultAddress, amountToDeposit);
 
             // Did that work as expected?
@@ -111,6 +111,14 @@ abstract contract ERC4626Supply is ActionBase {
     }
 
     ///  -----  Protocol specific overrides -----  ///
+
+    ///@notice Incerases the allowance to the vault
+    ///@param _underlying The underlying token address
+    ///@param _destination The destination address
+    ///@param _amount The amount of underlying token to deposit
+    function _increaseAllowance(address _underlying, address _destination, uint256 _amount) internal virtual {
+        IERC20(_underlying).safeIncreaseAllowance(_destination, _amount);
+    }
 
     /// @notice Gets the underlying token address from the vault
     /// @dev Override this for non-standard ERC4626 implementations

--- a/contracts/actions/notional/NotionalV3Supply.sol
+++ b/contracts/actions/notional/NotionalV3Supply.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {ERC4626Supply} from "../common/ERC4626Supply.sol";
+import {INotionalRouter} from "../../interfaces/notional/INotionalRouter.sol";
+import {INotionalPToken} from "../../interfaces/notional/INotionalPToken.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title NotionalV3Supply - Supplies tokens into Notional V3 vaults
+/// @notice This contract allows users to supply tokens into Notional V3 vaults
+/// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
+contract NotionalV3Supply is ERC4626Supply {
+    using SafeERC20 for IERC20;
+
+    /// @notice Address of the Notional V3 Router contract
+    address public immutable NOTIONAL_ROUTER;
+
+    /// @notice Initializes the NotionalV3Supply contract
+    /// @param _adminVault Address of the admin vault
+    /// @param _logger Address of the logger contract
+    /// @param _notionalRouter Address of the Notional Router contract
+    constructor(
+        address _adminVault,
+        address _logger,
+        address _notionalRouter
+    ) ERC4626Supply(_adminVault, _logger) {
+        NOTIONAL_ROUTER = _notionalRouter;
+    }
+
+    /// @inheritdoc ERC4626Supply
+    function _deposit(address _asset, uint256 _amount) internal override returns (uint256) {
+        // Notional needs the currencyId, not the pToken address
+        // We can get the currencyId from the pToken
+        uint16 _currencyId = INotionalPToken(_asset).currencyId();
+        return INotionalRouter(NOTIONAL_ROUTER).depositUnderlyingToken(
+            address(this),
+            _currencyId,
+            _amount
+        );
+    }
+
+    function _increaseAllowance(address _underlying, address, uint256 _amount) internal override{
+        // Notional needs the allowance to the router, not the pToken
+        IERC20(_underlying).safeIncreaseAllowance(NOTIONAL_ROUTER, _amount);
+    }
+
+    /// @inheritdoc ERC4626Supply
+    function protocolName() public pure override returns (string memory) {
+        return "NotionalV3";
+    }
+} 

--- a/contracts/actions/notional/NotionalV3Withdraw.sol
+++ b/contracts/actions/notional/NotionalV3Withdraw.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {ERC4626Withdraw} from "../common/ERC4626Withdraw.sol";
+import {INotionalPToken} from "../../interfaces/notional/INotionalPToken.sol";
+import {INotionalRouter} from "../../interfaces/notional/INotionalRouter.sol";
+
+/// @title NotionalV3Withdraw - Withdraws tokens from Notional V3 vault
+/// @notice This contract allows users to withdraw tokens from a Notional V3 vault
+/// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
+contract NotionalV3Withdraw is ERC4626Withdraw {
+    /// @notice Address of the Notional Router contract
+    address public immutable NOTIONAL_ROUTER;
+
+    /// @notice Initializes the NotionalWithdraw contract
+    /// @param _adminVault Address of the admin vault
+    /// @param _logger Address of the logger contract
+    /// @param _notionalRouterAddress Address of the Notional Router contract
+    constructor(address _adminVault, address _logger, address _notionalRouterAddress) ERC4626Withdraw(_adminVault, _logger) {
+        NOTIONAL_ROUTER = _notionalRouterAddress;
+    }
+
+
+    function _executeWithdraw(address _asset, uint256 _amount) internal override returns (uint256) {
+        // Notional needs the currencyId, not the pToken address
+        // We can get the currencyId from the pToken
+        uint16 _currencyId = INotionalPToken(_asset).currencyId();
+        return INotionalRouter(NOTIONAL_ROUTER).withdraw(_currencyId, uint88(_amount), true);
+    }
+
+    /// @inheritdoc ERC4626Withdraw
+    /// @notice Returns the protocol name
+    /// @return string "Fluid"
+    function protocolName() public pure override returns (string memory) {
+        return "NotionalV3";
+    }
+}

--- a/contracts/interfaces/notional/INotionalPToken.sol
+++ b/contracts/interfaces/notional/INotionalPToken.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface INotionalPToken {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event ProxyRenamed();
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Withdraw(address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
+
+    function EXCHANGE_RATE_PRECISION() external view returns (uint256);
+    function NOTIONAL() external view returns (address);
+    function allowance(address account, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool ret);
+    function asset() external view returns (address);
+    function balanceOf(address account) external view returns (uint256);
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+    function convertToShares(uint256 assets) external view returns (uint256 shares);
+    function currencyId() external view returns (uint16);
+    function decimals() external view returns (uint8);
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+    function exchangeRate() external view returns (uint256 rate);
+    function maxDeposit(address) external view returns (uint256 maxAssets);
+    function maxMint(address) external view returns (uint256 maxShares);
+    function maxRedeem(address owner) external view returns (uint256 maxShares);
+    function maxWithdraw(address owner) external view returns (uint256 maxAssets);
+    function mint(uint256 shares, address receiver) external returns (uint256 assets);
+    function name() external view returns (string memory);
+    function nativeDecimals() external view returns (uint8);
+    function previewDeposit(uint256 assets) external view returns (uint256 shares);
+    function previewMint(uint256 shares) external view returns (uint256 assets);
+    function previewRedeem(uint256 shares) external view returns (uint256 assets);
+    function previewWithdraw(uint256 assets) external view returns (uint256 shares);
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+    function symbol() external view returns (string memory);
+    function totalAssets() external view returns (uint256 totalManagedAssets);
+    function totalSupply() external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool ret);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool ret);
+    function underlying() external view returns (address);
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+} 

--- a/contracts/interfaces/notional/INotionalRouter.sol
+++ b/contracts/interfaces/notional/INotionalRouter.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface INotionalRouter {
+    /// @notice Deposits an underlying token (like USDC, DAI, etc.) into Notional
+    /// @param account The account to deposit for
+    /// @param currencyId The currency id of the token being deposited
+    /// @param amountExternalPrecision The amount to deposit in the token's native precision
+    /// @return The amount of pToken minted
+    function depositUnderlyingToken(
+        address account,
+        uint16 currencyId,
+        uint256 amountExternalPrecision
+    ) external payable returns (uint256);
+
+    /// @notice Withdraws assets from Notional
+    /// @param currencyId The currency id to withdraw
+    /// @param amountInternalPrecision The amount to withdraw in internal precision
+    /// @param redeemToUnderlying If true, redeems to the underlying token
+    /// @return The amount withdrawn in external precision
+    function withdraw(
+        uint16 currencyId,
+        uint88 amountInternalPrecision,
+        bool redeemToUnderlying
+    ) external returns (uint256);
+
+    /// @notice Withdraws via a proxy contract
+    /// @param currencyId The currency id to withdraw
+    /// @param account The account to withdraw from
+    /// @param receiver The address to receive the withdrawn tokens
+    /// @param spender The address approved to spend the tokens
+    /// @param withdrawAmountPrimeCash The amount of prime cash to withdraw
+    /// @return The amount withdrawn in external precision
+    function withdrawViaProxy(
+        uint16 currencyId,
+        address account,
+        address receiver,
+        address spender,
+        uint88 withdrawAmountPrimeCash
+    ) external returns (uint256);
+
+    /// @notice Settles an account's mature fCash positions
+    /// @param account The account to settle
+    /// @return True if the settlement was successful
+    function settleAccount(address account) external returns (bool);
+
+    /// @notice Enables bitmap currency for an account
+    /// @param currencyId The currency to enable bitmap for
+    function enableBitmapCurrency(uint16 currencyId) external;
+
+    /// @notice Enables or disables prime borrow capability
+    /// @param allowPrimeBorrow True to enable prime borrow
+    function enablePrimeBorrow(bool allowPrimeBorrow) external;
+
+    /// @notice Redeems nTokens for the underlying asset
+    /// @param redeemer The account redeeming the nTokens
+    /// @param currencyId The currency id of the nToken
+    /// @param tokensToRedeem_ The amount of nTokens to redeem
+    /// @return The amount of underlying tokens received
+    function nTokenRedeem(
+        address redeemer,
+        uint16 currencyId,
+        uint96 tokensToRedeem_
+    ) external returns (int256);
+
+    /// @notice Returns various library addresses used by Notional
+    function getLibInfo() external pure returns (address, address, address);
+    
+    /// @notice Returns the owner of the Notional protocol
+    function owner() external view returns (address);
+    
+    /// @notice Returns the pause guardian address
+    function pauseGuardian() external view returns (address);
+    
+    /// @notice Returns the pause router address
+    function pauseRouter() external view returns (address);
+} 

--- a/tests/actions.ts
+++ b/tests/actions.ts
@@ -39,7 +39,8 @@ interface SupplyArgs extends BaseActionArgs {
     | 'ClearpoolSupply'
     | 'SparkSupply'
     | 'AcrossSupply'
-    | 'MorphoSupply';
+    | 'MorphoSupply'
+    | 'NotionalV3Supply';
   poolAddress?: string;
   feeBasis?: number;
   amount?: string | BigInt;
@@ -53,7 +54,8 @@ interface WithdrawArgs extends BaseActionArgs {
     | 'ClearpoolWithdraw'
     | 'SparkWithdraw'
     | 'AcrossWithdraw'
-    | 'MorphoWithdraw';
+    | 'MorphoWithdraw'
+    | 'NotionalV3Withdraw';
   poolAddress?: string;
   feeBasis?: number;
   amount?: string | BigInt;
@@ -443,5 +445,33 @@ export const actionDefaults: Record<string, ActionArgs> = {
       encodingVariables: ['poolId', 'feeBasis', 'amount', 'maxSharesBurned'],
     },
     sdkArgs: ['poolAddress', 'amount', 'maxSharesBurned', 'feeBasis'],
+  },
+  NotionalV3Supply: {
+    type: 'NotionalV3Supply',
+    useSDK: false,
+    value: 0,
+    safeOperation: 1,
+    poolAddress: tokenConfig.pUSDC.address,
+    feeBasis: 0,
+    amount: '0',
+    minSharesReceived: '0',
+    encoding: {
+      inputParams: ['bytes4', 'uint16', 'uint256', 'uint256'],
+      encodingVariables: ['poolId', 'feeBasis', 'amount', 'minSharesReceived'],
+    },
+  },
+  NotionalV3Withdraw: {
+    type: 'NotionalV3Withdraw',
+    useSDK: false,
+    value: 0,
+    safeOperation: 1,
+    poolAddress: tokenConfig.pUSDC.address,
+    feeBasis: 0,
+    amount: '0',
+    maxSharesBurned: ethers.MaxUint256.toString(),
+    encoding: {
+      inputParams: ['bytes4', 'uint16', 'uint256', 'uint256'],
+      encodingVariables: ['poolId', 'feeBasis', 'amount', 'maxSharesBurned'],
+    },
   },
 };

--- a/tests/actions/notional/NotionalV3.test.ts
+++ b/tests/actions/notional/NotionalV3.test.ts
@@ -1,0 +1,460 @@
+import { BytesLike } from 'ethers';
+import { network } from 'hardhat';
+import { ethers, expect, Signer } from '../..';
+import { actionTypes } from '../../../tests/actions';
+import { tokenConfig } from '../../../tests/constants';
+import {
+  AdminVault,
+  NotionalV3Supply,
+  NotionalV3Withdraw,
+  IERC20,
+  INotionalPToken,
+  Logger,
+} from '../../../typechain-types';
+import { ACTION_LOG_IDS, BalanceUpdateLog } from '../../logs';
+import {
+  calculateExpectedFee,
+  decodeLoggerLog,
+  deploy,
+  executeAction,
+  getBaseSetup,
+  log,
+  getBytes4,
+} from '../../utils';
+import { fundAccountWithToken } from '../../utils-stable';
+
+describe('Notional tests', () => {
+  let signer: Signer;
+  let safeAddr: string;
+  let loggerAddress: string;
+  let logger: Logger;
+  let snapshotId: string;
+  let USDC: IERC20;
+  let pUSDC: INotionalPToken;
+  let NotionalV3SupplyContract: NotionalV3Supply;
+  let NotionalV3WithdrawContract: NotionalV3Withdraw;
+  let NotionalV3SupplyAddress: string;
+  let NotionalV3WithdrawAddress: string;
+  let adminVault: AdminVault;
+  const NOTIONAL_ROUTER = '0x6e7058c91F85E0F6db4fc9da2CA41241f5e4263f';
+  const PUSDC_ADDRESS = '0xaEeAfB1259f01f363d09D7027ad80a9d442de762';
+
+  // Run tests for each supported token
+  const testCases: Array<{
+    token: keyof typeof tokenConfig;
+    poolAddress: string;
+    pToken: () => INotionalPToken;
+  }> = [
+    {
+      token: 'USDC',
+      poolAddress: PUSDC_ADDRESS,
+      pToken: () => pUSDC,
+    },
+  ];
+
+  before(async () => {
+    [signer] = await ethers.getSigners();
+    const baseSetup = await getBaseSetup(signer);
+    if (!baseSetup) {
+      throw new Error('Base setup not deployed');
+    }
+    safeAddr = (await baseSetup.safe.getAddress()) as string;
+    loggerAddress = (await baseSetup.logger.getAddress()) as string;
+    logger = await ethers.getContractAt('Logger', loggerAddress);
+    adminVault = await baseSetup.adminVault;
+
+    // Fetch the USDC token
+    USDC = await ethers.getContractAt('IERC20', tokenConfig.USDC.address);
+    pUSDC = await ethers.getContractAt('INotionalPToken', PUSDC_ADDRESS);
+
+    // Initialize NotionalV3Supply and NotionalV3Withdraw actions
+    NotionalV3SupplyContract = await deploy(
+      'NotionalV3Supply',
+      signer,
+      await adminVault.getAddress(),
+      loggerAddress,
+      NOTIONAL_ROUTER
+    );
+    NotionalV3WithdrawContract = await deploy(
+      'NotionalV3Withdraw',
+      signer,
+      await adminVault.getAddress(),
+      loggerAddress,
+      NOTIONAL_ROUTER
+    );
+    NotionalV3SupplyAddress = await NotionalV3SupplyContract.getAddress();
+    NotionalV3WithdrawAddress = await NotionalV3WithdrawContract.getAddress();
+
+    // Register actions
+    await adminVault.proposeAction(getBytes4(NotionalV3SupplyAddress), NotionalV3SupplyAddress);
+    await adminVault.addAction(getBytes4(NotionalV3SupplyAddress), NotionalV3SupplyAddress);
+    await adminVault.proposeAction(getBytes4(NotionalV3WithdrawAddress), NotionalV3WithdrawAddress);
+    await adminVault.addAction(getBytes4(NotionalV3WithdrawAddress), NotionalV3WithdrawAddress);
+
+    // Add pUSDC to supported pools
+    await adminVault.proposePool('NotionalV3', PUSDC_ADDRESS);
+    await adminVault.addPool('NotionalV3', PUSDC_ADDRESS);
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send('evm_snapshot');
+  });
+
+  afterEach(async () => {
+    await network.provider.send('evm_revert', [snapshotId]);
+  });
+
+  describe('Notional Supply', () => {
+    testCases.forEach(({ token, poolAddress, pToken }) => {
+      describe(`Testing ${token}`, () => {
+        it('Should deposit', async () => {
+          const amount = ethers.parseUnits('2000', tokenConfig[token].decimals);
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+          await fundAccountWithToken(safeAddr, token, amount);
+
+          const initialTokenBalance = await tokenContract.balanceOf(safeAddr);
+          const initialNotionalBalance = await pToken().balanceOf(safeAddr);
+
+          await executeAction({
+            type: 'NotionalV3Supply',
+            amount,
+            minSharesReceived: '0',
+          });
+
+          const finalTokenBalance = await tokenContract.balanceOf(safeAddr);
+          const finalNotionalBalance = await pToken().balanceOf(safeAddr);
+
+          expect(finalTokenBalance).to.equal(initialTokenBalance - amount);
+          expect(finalNotionalBalance).to.be.greaterThan(initialNotionalBalance);
+        });
+
+        it('Should deposit max', async () => {
+          const amount = ethers.parseUnits('2000', tokenConfig[token].decimals);
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+          await fundAccountWithToken(safeAddr, token, amount);
+
+          const initialTokenBalance = await tokenContract.balanceOf(safeAddr);
+          const initialNotionalBalance = await pToken().balanceOf(safeAddr);
+
+          expect(initialTokenBalance).to.equal(amount);
+
+          await executeAction({
+            type: 'NotionalV3Supply',
+            poolAddress,
+            amount: ethers.MaxUint256,
+            minSharesReceived: '0',
+          });
+
+          expect(await tokenContract.balanceOf(safeAddr)).to.equal(0);
+          expect(await pToken().balanceOf(safeAddr)).to.be.greaterThan(initialNotionalBalance);
+        });
+
+        it('Should take fees on deposit', async () => {
+          const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+          await fundAccountWithToken(safeAddr, token, amount);
+
+          const feeConfig = await adminVault.feeConfig();
+          const feeRecipient = feeConfig.recipient;
+          const feeRecipientTokenBalanceBefore = await tokenContract.balanceOf(feeRecipient);
+          const feeRecipientNotionalBalanceBefore = await pToken().balanceOf(feeRecipient);
+
+          // Do an initial deposit
+          const firstTx = await executeAction({
+            type: 'NotionalV3Supply',
+            poolAddress,
+            amount,
+            minSharesReceived: '0',
+            feeBasis: 10,
+          });
+
+          const notionalBalanceAfterFirstTx = await pToken().balanceOf(safeAddr);
+
+          // Time travel 1 year
+          const protocolId = BigInt(
+            ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['string'], ['NotionalV3']))
+          );
+          const initialFeeTimestamp = await adminVault.lastFeeTimestamp(safeAddr, protocolId, poolAddress);
+          const finalFeeTimestamp = initialFeeTimestamp + BigInt(60 * 60 * 24 * 365);
+          await network.provider.send('evm_setNextBlockTimestamp', [finalFeeTimestamp.toString()]);
+
+          // Do another deposit to trigger fees
+          const secondTx = await executeAction({
+            type: 'NotionalV3Supply',
+            poolAddress,
+            amount: '0',
+            minSharesReceived: '0',
+            feeBasis: 10,
+          });
+
+          const expectedFee = await calculateExpectedFee(
+            (await firstTx.wait()) ?? (() => { throw new Error('First deposit transaction failed'); })(),
+            (await secondTx.wait()) ?? (() => { throw new Error('Second deposit transaction failed'); })(),
+            10,
+            notionalBalanceAfterFirstTx
+          );
+          const expectedFeeRecipientBalance = feeRecipientNotionalBalanceBefore + expectedFee;
+
+          // Check fees were taken in pTokens, not underlying
+          expect(await tokenContract.balanceOf(feeRecipient)).to.equal(feeRecipientTokenBalanceBefore);
+          expect(await pToken().balanceOf(feeRecipient)).to.equal(expectedFeeRecipientBalance);
+        });
+      });
+    });
+
+    describe('General tests', () => {
+      it('Should emit the correct log on deposit', async () => {
+        const token = 'USDC';
+        const amount = ethers.parseUnits('2000', tokenConfig[token].decimals);
+        await fundAccountWithToken(safeAddr, token, amount);
+        const strategyId: number = 42;
+        const poolId: BytesLike = ethers.keccak256(PUSDC_ADDRESS).slice(0, 10);
+
+        const tx = await executeAction({
+          type: 'NotionalV3Supply',
+          amount,
+          minSharesReceived: '0',
+        });
+
+        const logs = await decodeLoggerLog(tx);
+        log('Logs:', logs);
+
+        expect(logs).to.have.length(1);
+        expect(logs[0]).to.have.property('eventId', BigInt(ACTION_LOG_IDS.BALANCE_UPDATE));
+
+        const txLog = logs[0] as BalanceUpdateLog;
+        expect(txLog).to.have.property('safeAddress', safeAddr);
+        expect(txLog).to.have.property('strategyId', BigInt(strategyId));
+        expect(txLog).to.have.property('poolId', poolId);
+        expect(txLog).to.have.property('balanceBefore', BigInt(0));
+        expect(txLog).to.have.property('balanceAfter');
+        expect(txLog).to.have.property('feeInTokens');
+        expect(txLog.balanceAfter).to.be.a('bigint');
+        expect(txLog.balanceAfter).to.not.equal(BigInt(0));
+      });
+
+      it('Should initialize last fee timestamp', async () => {
+        const protocolId = BigInt(
+          ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['string'], ['NotionalV3']))
+        );
+        const initialLastFeeTimestamp = await adminVault.lastFeeTimestamp(
+          safeAddr,
+          protocolId,
+          PUSDC_ADDRESS
+        );
+        expect(initialLastFeeTimestamp).to.equal(BigInt(0));
+
+        await fundAccountWithToken(safeAddr, 'USDC', 1000);
+
+        const tx = await executeAction({
+          type: 'NotionalV3Supply',
+          minSharesReceived: '0',
+          amount: '0'
+        });
+
+        const txReceipt = await tx.wait();
+        if (!txReceipt) {
+          throw new Error('Transaction receipt not found');
+        }
+        const block = await ethers.provider.getBlock(txReceipt.blockNumber);
+        if (!block) {
+          throw new Error('Block not found');
+        }
+        const finalLastFeeTimestamp = await adminVault.lastFeeTimestamp(
+          safeAddr,
+          protocolId,
+          PUSDC_ADDRESS
+        );
+        expect(finalLastFeeTimestamp).to.equal(BigInt(block.timestamp));
+      });
+
+      it('Should have deposit action type', async () => {
+        const actionType = await NotionalV3SupplyContract.actionType();
+        expect(actionType).to.equal(actionTypes.DEPOSIT_ACTION);
+      });
+
+      it('Should reject invalid token', async () => {
+        await expect(
+          executeAction({
+            type: 'NotionalV3Supply',
+            amount: '0',
+            poolAddress: '0x0000000000000000000000000000000000000000',
+            minSharesReceived: '0',
+          })
+        ).to.be.revertedWith('GS013');
+      });
+    });
+  });
+
+  describe('Notional Withdraw', () => {
+    beforeEach(async () => {
+      // Do an empty deposit to initialize the fee timestamp
+      for (const { poolAddress } of testCases) {
+        await executeAction({
+          type: 'NotionalV3Supply',
+          poolAddress,
+          amount: '0',
+          minSharesReceived: '0',
+        });
+      }
+    });
+
+    testCases.forEach(({ token, poolAddress, pToken }) => {
+      describe(`Testing ${token}`, () => {
+        it('Should withdraw', async () => {
+          const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+
+          // First supply to have something to withdraw
+          await fundAccountWithToken(safeAddr, token, amount);
+          await executeAction({
+            type: 'NotionalV3Supply',
+            poolAddress,
+            amount,
+            minSharesReceived: '0',
+          });
+
+          const initialTokenBalance = await tokenContract.balanceOf(safeAddr);
+          const initialNotionalBalance = await pToken().balanceOf(safeAddr);
+
+          await executeAction({
+            type: 'NotionalV3Withdraw',
+            poolAddress,
+            amount,
+          });
+
+          const finalTokenBalance = await tokenContract.balanceOf(safeAddr);
+          const finalNotionalBalance = await pToken().balanceOf(safeAddr);
+
+          expect(finalTokenBalance).to.be.greaterThan(initialTokenBalance);
+          expect(finalNotionalBalance).to.be.lessThan(initialNotionalBalance);
+        });
+
+        it('Should withdraw the maximum amount', async () => {
+          const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+
+          // First supply to have something to withdraw
+          await fundAccountWithToken(safeAddr, token, amount);
+          await executeAction({
+            type: 'NotionalV3Supply',
+            poolAddress,
+            amount,
+            minSharesReceived: '0',
+          });
+
+          const initialNotionalBalance = await pToken().balanceOf(safeAddr);
+          expect(initialNotionalBalance).to.be.gt(0);
+
+          await executeAction({
+            type: 'NotionalV3Withdraw',
+            poolAddress,
+            amount: ethers.MaxUint256,
+          });
+
+          // Notional leaves some dust in the vault, so we expect to have less than 1 shares worth left behind
+          const minWithdraw = await pToken().exchangeRate();
+          expect(await pToken().balanceOf(safeAddr)).to.be.lessThan(minWithdraw);
+          expect(await tokenContract.balanceOf(safeAddr)).to.be.greaterThan(0);
+        });
+
+        it('Should take fees on withdraw', async () => {
+          const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+          await fundAccountWithToken(safeAddr, token, amount);
+
+          const feeConfig = await adminVault.feeConfig();
+          const feeRecipient = feeConfig.recipient;
+          const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+          const feeRecipientTokenBalanceBefore = await tokenContract.balanceOf(feeRecipient);
+          const feeRecipientNotionalBalanceBefore = await pToken().balanceOf(feeRecipient);
+
+          const supplyTx = await executeAction({
+            type: 'NotionalV3Supply',
+            amount,
+            minSharesReceived: '0',
+            feeBasis: 10,
+          });
+
+          const notionalBalanceAfterSupply = await pToken().balanceOf(safeAddr);
+
+          const protocolId = BigInt(
+            ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['string'], ['NotionalV3']))
+          );
+          const initialFeeTimestamp = await adminVault.lastFeeTimestamp(safeAddr, protocolId, poolAddress);
+          const finalFeeTimestamp = initialFeeTimestamp + BigInt(60 * 60 * 24 * 365);
+          await network.provider.send('evm_setNextBlockTimestamp', [finalFeeTimestamp.toString()]);
+
+          const withdrawTx = await executeAction({
+            type: 'NotionalV3Withdraw',
+            poolAddress,
+            amount: '1',
+            feeBasis: 10,
+          });
+
+          const expectedFee = await calculateExpectedFee(
+            (await supplyTx.wait()) ?? (() => { throw new Error('Supply transaction failed'); })(),
+            (await withdrawTx.wait()) ?? (() => { throw new Error('Withdraw transaction failed'); })(),
+            10,
+            notionalBalanceAfterSupply
+          );
+          const expectedFeeRecipientBalance = feeRecipientNotionalBalanceBefore + expectedFee;
+
+          expect(await tokenContract.balanceOf(feeRecipient)).to.equal(feeRecipientTokenBalanceBefore);
+          expect(await pToken().balanceOf(feeRecipient)).to.be.greaterThanOrEqual(expectedFeeRecipientBalance);
+        });
+      });
+    });
+
+    describe('General tests', () => {
+      it('Should emit the correct log on withdraw', async () => {
+        const token = 'USDC';
+        const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+        const tokenContract = await ethers.getContractAt('IERC20', tokenConfig[token].address);
+        const strategyId: number = 42;
+        const poolId: BytesLike = ethers.keccak256(PUSDC_ADDRESS).slice(0, 10);
+
+        // First supply to have something to withdraw
+        await fundAccountWithToken(safeAddr, token, amount);
+        await executeAction({
+          type: 'NotionalV3Supply',
+          amount,
+          minSharesReceived: '0',
+        });
+
+        const tx = await executeAction({
+          type: 'NotionalV3Withdraw',
+          amount: ethers.MaxUint256,
+        });
+
+        const logs = await decodeLoggerLog(tx);
+        log('Logs:', logs);
+
+        expect(logs).to.have.length(1);
+        expect(logs[0]).to.have.property('eventId', BigInt(ACTION_LOG_IDS.BALANCE_UPDATE));
+
+        const txLog = logs[0] as BalanceUpdateLog;
+        expect(txLog).to.have.property('safeAddress', safeAddr);
+        expect(txLog).to.have.property('strategyId', BigInt(strategyId));
+        expect(txLog).to.have.property('poolId', poolId);
+        expect(txLog).to.have.property('balanceBefore');
+        expect(txLog).to.have.property('balanceAfter');
+        expect(txLog).to.have.property('feeInTokens');
+      });
+
+      it('Should have withdraw action type', async () => {
+        const actionType = await NotionalV3WithdrawContract.actionType();
+        expect(actionType).to.equal(actionTypes.WITHDRAW_ACTION);
+      });
+
+      it('Should reject invalid token', async () => {
+        await expect(
+          executeAction({
+            type: 'NotionalV3Withdraw',
+            poolAddress: '0x0000000000000000000000000000000000000000',
+            amount: '1',
+          })
+        ).to.be.revertedWith('GS013');
+      });
+    });
+  });
+}); 

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -205,10 +205,10 @@ export const tokenConfig = {
     whale: '0x8a95a711A56bD837D678ab299dE7B1Ec9863051C',
     decimals: 18,
   },
-<<<<<<< HEAD
   pUSDC: {
     address: '0xaEeAfB1259f01f363d09D7027ad80a9d442de762',
-=======
+    decimals: 18,
+  },
   yearnV3_DAI: {
     address: '0x92545bCE636E6eE91D88D2D017182cD0bd2fC22e',
     whale: '0x38E3d865e34f7367a69f096C80A4fc329DB38BF4',
@@ -247,7 +247,6 @@ export const tokenConfig = {
   morpho_blue_gtUSDT: {
     address: '0x8CB3649114051cA5119141a34C200D65dc0Faa73',
     whale: '0xdb02Da0A36c7b19461fD00DA62D4fF3be884668e',
->>>>>>> origin/main
     decimals: 18,
   },
 };

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -194,6 +194,10 @@ export const tokenConfig = {
     whale: '0x8a95a711A56bD837D678ab299dE7B1Ec9863051C',
     decimals: 18,
   },
+  pUSDC: {
+    address: '0xaEeAfB1259f01f363d09D7027ad80a9d442de762',
+    decimals: 18,
+  },
 };
 
 export const NEXUS_QUOTES = {


### PR DESCRIPTION
Notional V3 fundamentally is a 4626 vault, however all interactions are done via a router contract and that router contract forwards calls to the pools using a currencyId value.

So we store the router contract into the action contracts.
We can pass in the pool address and from that pool we can get the underlying asset address and the currencyID.
The other complication was the funds are sent to the router, not the pool, so in the 4626Supply contract I needed to separate out the allowance increase call so that I can override it for Notional.