### PR TITLE
yearnV1 withdraw should withdraw underlying amount, not shares

### DIFF
--- a/contracts/actions/yearn/YearnWithdraw.sol
+++ b/contracts/actions/yearn/YearnWithdraw.sol
@@ -8,18 +8,44 @@ import {ERC4626Withdraw} from "../common/ERC4626Withdraw.sol";
 /// @notice This contract allows users to withdraw tokens from a Yearn vault
 /// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
 contract YearnWithdraw is ERC4626Withdraw {
+
     constructor(address _adminVault, address _logger) ERC4626Withdraw(_adminVault, _logger) {}
 
     /// @inheritdoc ERC4626Withdraw
     /// @dev We are overriding because Yearn doesn't implement an Owner parameter for withdrawals, it's always the caller
     function _executeWithdraw(address vault, uint256 amount) internal virtual override returns (uint256 _sharesBurned) {
-        _sharesBurned = IYearnVault(vault).withdraw(amount);
+        IYearnVault yVault = IYearnVault(vault);
+        
+        // Calculate shares using pricePerShare
+        uint256 pricePerShare = yVault.pricePerShare();
+        uint256 decimals = yVault.decimals();
+        uint256 sharesToWithdraw = (amount * 10 ** decimals) / pricePerShare;
+        
+        // Add just 1 share to handle rounding
+        sharesToWithdraw = sharesToWithdraw + 1;
+        
+        // Check our actual balance and cap withdrawal amount
+        uint256 shareBalance = yVault.balanceOf(address(this));
+        if (sharesToWithdraw > shareBalance) {
+            sharesToWithdraw = shareBalance;
+        }
+        
+        // Execute withdrawal with max loss of 1 BPS (0.01%)
+        uint256 _tokensReceived = yVault.withdraw(sharesToWithdraw, address(this), 1);
+        uint256 sharesAfter = yVault.balanceOf(address(this));
+        _sharesBurned = shareBalance - sharesAfter;
     }
 
     /// @inheritdoc ERC4626Withdraw
-    /// @dev For yearn we can use the balance of shares as there's no fees or limits on withdrawals
     function _getMaxWithdraw(address vault) internal view virtual override returns (uint256) {
-        return IYearnVault(vault).balanceOf(address(this));
+        IYearnVault yVault = IYearnVault(vault);
+        
+        uint256 shares = yVault.balanceOf(address(this));
+        if (shares == 0) return 0;
+        
+        uint256 pricePerShare = yVault.pricePerShare();
+        uint256 decimals = yVault.decimals();
+        return (shares * pricePerShare) / 10 ** decimals;
     }
 
     /// @inheritdoc ERC4626Withdraw

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -96,8 +96,8 @@ export const tokenConfig = {
     decimals: 6,
   },
   yDAI: {
-    address: '0x92545bCE636E6eE91D88D2D017182cD0bd2fC22e',
-    whale: '0x38E3d865e34f7367a69f096C80A4fc329DB38BF4',
+    address: '0xdA816459F1AB5631232FE5e97a05BBBb94970c95',
+    whale: '0x5C6374a2ac4EBC38DeA0Fc1F8716e5Ea1AdD94dd',
     decimals: 18,
   },
   yvDAI: {


### PR DESCRIPTION
Yearn V1 now includes share price calculations so we're no longer confusing the underlying and the share assets.
Added a test that should pick this problem up.