### PR TITLE
Dc/add share tests

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -48,6 +48,7 @@ contract Errors {
         uint256 _maxAllowed
     );
     error Action_InvalidPool(string _protocolName, uint8 _actionType);
+    error Action_UnderlyingReceivedLessThanExpected(uint256 _underlyingReceived, uint256 _expected);
 
     // CompoundV2Supply errors
     error Action_CompoundError(string _protocolName, uint8 _actionType, uint256 _errorCode);

--- a/contracts/actions/common/ShareBasedWithdraw.sol
+++ b/contracts/actions/common/ShareBasedWithdraw.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {Errors} from "../../Errors.sol";
+import {ActionBase} from "../ActionBase.sol";
+
+/// @title ShareBasedWithdraw - Burns vault shares and receives underlying tokens in return
+/// @notice This contract allows users to withdraw tokens from vaults that require share-based withdrawals
+/// @dev Inherits from ActionBase and implements generic share-based withdraw functionality
+/// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
+abstract contract ShareBasedWithdraw is ActionBase {
+    /// @notice Parameters for the withdraw action
+    /// @param poolId ID of vault contract
+    /// @param feeBasis Fee percentage to apply (in basis points, e.g., 100 = 1%)
+    /// @param sharesToBurn Amount of shares to burn
+    /// @param minUnderlyingReceived Minimum amount of underlying tokens to receive
+    struct Params {
+        bytes4 poolId;
+        uint16 feeBasis;
+        uint256 sharesToBurn;
+        uint256 minUnderlyingReceived;
+    }
+
+    constructor(address _adminVault, address _logger) ActionBase(_adminVault, _logger) {}
+
+    ///  -----   Core logic -----  ///
+
+    /// @inheritdoc ActionBase
+    function executeAction(bytes memory _callData, uint16 _strategyId) public payable override {
+        // Parse inputs
+        Params memory inputData = _parseInputs(_callData);
+
+        // Check inputs
+        ADMIN_VAULT.checkFeeBasis(inputData.feeBasis);
+        address vault = ADMIN_VAULT.getPoolAddress(protocolName(), inputData.poolId);
+
+        // Execute action
+        (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) = _withdrawFromVault(inputData, vault);
+
+        // Log event
+        LOGGER.logActionEvent(
+            LogType.BALANCE_UPDATE,
+            _encodeBalanceUpdate(_strategyId, inputData.poolId, sharesBefore, sharesAfter, feeInTokens)
+        );
+    }
+
+    /// @dev Withdraw logic, external calls are separated out to allow for overrides
+    function _withdrawFromVault(
+        Params memory _inputData,
+        address _vaultAddress
+    ) private returns (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) {
+        // for logging, get the balance before
+        sharesBefore = _getBalance(_vaultAddress);
+
+        feeInTokens = _processFee(_vaultAddress, _inputData.feeBasis, _vaultAddress, sharesBefore);
+
+        uint256 maxShares = _getBalance(_vaultAddress);
+        uint256 sharesToWithdraw = _inputData.sharesToBurn > maxShares ? maxShares : _inputData.sharesToBurn;
+
+        require(sharesToWithdraw != 0, Errors.Action_ZeroAmount(protocolName(), actionType()));
+
+        // Perform the withdraw
+        _executeWithdraw(_vaultAddress, sharesToWithdraw, _inputData.minUnderlyingReceived);
+
+        // for logging, get the balance after
+        sharesAfter = _getBalance(_vaultAddress);
+    }
+
+    /// @notice Parses the input data from bytes to Params struct
+    /// @param _callData Encoded call data
+    /// @return inputData Decoded Params struct
+    function _parseInputs(bytes memory _callData) private pure returns (Params memory inputData) {
+        inputData = abi.decode(_callData, (Params));
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure override returns (uint8) {
+        return uint8(ActionType.WITHDRAW_ACTION);
+    }
+
+    /// -----  Protocol specific overrides ----- ///
+
+    /// @notice Executes the withdraw from the vault
+    /// @dev Override for non-standard withdraw implementations
+    /// @param _vaultAddress The vault address
+    /// @param _sharesToBurn The amount of shares to burn
+    /// @param _minUnderlyingReceived The minimum amount of underlying tokens to receive
+    function _executeWithdraw(
+        address _vaultAddress,
+        uint256 _sharesToBurn,
+        uint256 _minUnderlyingReceived
+    ) internal virtual;
+
+    /// @dev Override for non-standard balance calculations
+    function _getBalance(address _vaultAddress) internal view virtual returns (uint256);
+
+    /// @inheritdoc ActionBase
+    function protocolName() public pure virtual override returns (string memory);
+} 

--- a/contracts/actions/vesper/VesperWithdraw.sol
+++ b/contracts/actions/vesper/VesperWithdraw.sol
@@ -4,97 +4,44 @@ pragma solidity =0.8.28;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Errors} from "../../Errors.sol";
-import {ActionBase} from "../ActionBase.sol";
+import {ShareBasedWithdraw} from "../common/ShareBasedWithdraw.sol";
 import {IVesperPool} from "../../interfaces/vesper/IVesperPool.sol";
 
 /// @title VesperWithdraw - Withdraws tokens from Vesper Pool
 /// @notice This contract allows users to withdraw tokens from Vesper Pool
 /// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
-contract VesperWithdraw is ActionBase {
+contract VesperWithdraw is ShareBasedWithdraw {
     using SafeERC20 for IERC20;
 
-    /// @notice Parameters for the withdraw action
-    /// @param poolId The pool ID
-    /// @param feeBasis Fee percentage to apply (in basis points, e.g., 100 = 1%)
-    /// @param withdrawAmount Amount of liquidity to withdraw in underlying token
-    /// @param maxSharesBurned Maximum number of shares to burn
-    struct Params {
-        bytes4 poolId;
-        uint16 feeBasis;
-        uint256 withdrawAmount;
-        uint256 maxSharesBurned;
-    }
+    constructor(address _adminVault, address _logger) ShareBasedWithdraw(_adminVault, _logger) {}
 
-    constructor(address _adminVault, address _logger) ActionBase(_adminVault, _logger) {}
+    function _executeWithdraw(
+        address _vaultAddress,
+        uint256 _sharesToBurn,
+        uint256 _minUnderlyingReceived
+    ) internal override {
+        IVesperPool pool = IVesperPool(_vaultAddress);
+        IERC20 underlyingToken = IERC20(pool.token());
 
-    /// @inheritdoc ActionBase
-    function executeAction(bytes memory _callData, uint16 _strategyId) public payable override {
-        // Parse inputs
-        Params memory inputData = _parseInputs(_callData);
-
-        // Check inputs
-        ADMIN_VAULT.checkFeeBasis(inputData.feeBasis);
-
-        address poolAddress = ADMIN_VAULT.getPoolAddress(protocolName(), inputData.poolId);
-        // Execute action
-        (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) = _withdrawLiquidity(inputData, poolAddress);
-
-        // Log event
-        LOGGER.logActionEvent(
-            LogType.BALANCE_UPDATE,
-            _encodeBalanceUpdate(_strategyId, inputData.poolId, sharesBefore, sharesAfter, feeInTokens)
-        );
-    }
-
-    function _withdrawLiquidity(
-        Params memory _inputData,
-        address _poolAddress
-    ) internal returns (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) {
-        // Get the LP token address
-        IVesperPool pool = IVesperPool(_poolAddress);
-
-        // Get initial balance
-        sharesBefore = IERC20(_poolAddress).balanceOf(address(this));
-
-        feeInTokens = _processFee(_poolAddress, _inputData.feeBasis, _poolAddress, sharesBefore);
-
-        // Get price per share once
-        uint256 pricePerShare = pool.pricePerShare();
-        
-        uint256 underlyingBalance = (sharesBefore * pricePerShare) / 1e18;
-        uint256 amountToWithdraw = _inputData.withdrawAmount >= underlyingBalance
-            ? sharesBefore
-            : (_inputData.withdrawAmount * 1e18) / pricePerShare;
-
-        require(amountToWithdraw != 0, Errors.Action_ZeroAmount(protocolName(), actionType()));
+        // Get underlying balance before withdrawal
+        uint256 balanceBefore = underlyingToken.balanceOf(address(this));
 
         // Execute withdrawal
-        pool.withdraw(amountToWithdraw);
+        pool.withdraw(_sharesToBurn);
 
-        sharesAfter = IERC20(_poolAddress).balanceOf(address(this));
-        // Calculate shares burned
-        uint256 sharesBurned = sharesBefore - sharesAfter;
+        // Calculate actual underlying received
+        uint256 underlyingReceived = underlyingToken.balanceOf(address(this)) - balanceBefore;
         require(
-            sharesBurned <= _inputData.maxSharesBurned,
-            Errors.Action_MaxSharesBurnedExceeded(
-                protocolName(),
-                uint8(actionType()),
-                sharesBurned,
-                _inputData.maxSharesBurned
-            )
+            underlyingReceived >= _minUnderlyingReceived,
+            Errors.Action_UnderlyingReceivedLessThanExpected(underlyingReceived, _minUnderlyingReceived)
         );
     }
 
-    function _parseInputs(bytes memory _callData) private pure returns (Params memory inputData) {
-        inputData = abi.decode(_callData, (Params));
+    function _getBalance(address _vaultAddress) internal view override returns (uint256) {
+        return IERC20(_vaultAddress).balanceOf(address(this));
     }
 
-    /// @inheritdoc ActionBase
-    function actionType() public pure override returns (uint8) {
-        return uint8(ActionType.WITHDRAW_ACTION);
-    }
-
-    /// @inheritdoc ActionBase
+    /// @inheritdoc ShareBasedWithdraw
     function protocolName() public pure override returns (string memory) {
         return "Vesper";
     }

--- a/contracts/actions/yearn/YearnWithdraw.sol
+++ b/contracts/actions/yearn/YearnWithdraw.sol
@@ -2,52 +2,36 @@
 pragma solidity =0.8.28;
 
 import {IYearnVault} from "../../interfaces/yearn/IYearnVault.sol";
-import {ERC4626Withdraw} from "../common/ERC4626Withdraw.sol";
+import {ShareBasedWithdraw} from "../common/ShareBasedWithdraw.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Errors} from "../../Errors.sol";
 
 /// @title YearnWithdraw - Burns yTokens and receives underlying tokens in return
 /// @notice This contract allows users to withdraw tokens from a Yearn vault
 /// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
-contract YearnWithdraw is ERC4626Withdraw {
-    constructor(address _adminVault, address _logger) ERC4626Withdraw(_adminVault, _logger) {}
+contract YearnWithdraw is ShareBasedWithdraw {
+    constructor(address _adminVault, address _logger) ShareBasedWithdraw(_adminVault, _logger) {}
 
-    /// @inheritdoc ERC4626Withdraw
-    /// @dev We are overriding because Yearn doesn't implement an Owner parameter for withdrawals, it's always the caller
-    function _executeWithdraw(address vault, uint256 amount) internal virtual override returns (uint256 _sharesBurned) {
-        IYearnVault yVault = IYearnVault(vault);
-
-        // Calculate shares using pricePerShare
-        uint256 pricePerShare = yVault.pricePerShare();
-        uint256 decimals = yVault.decimals();
-        uint256 sharesToWithdraw = (amount * 10 ** decimals) / pricePerShare;
-
-        // Add just 1 share to handle rounding
-        sharesToWithdraw = sharesToWithdraw + 1;
-
-        // Check our actual balance and cap withdrawal amount
-        uint256 shareBalance = yVault.balanceOf(address(this));
-        if (sharesToWithdraw > shareBalance) {
-            sharesToWithdraw = shareBalance;
-        }
+    function _executeWithdraw(
+        address _vaultAddress,
+        uint256 _sharesToBurn,
+        uint256 _minUnderlyingReceived
+    ) internal override {
+        IYearnVault yVault = IYearnVault(_vaultAddress);
 
         // Execute withdrawal with max loss of 1 BPS (0.01%)
-        yVault.withdraw(sharesToWithdraw, address(this), 1);
-        uint256 sharesAfter = yVault.balanceOf(address(this));
-        _sharesBurned = shareBalance - sharesAfter;
+        uint256 underlyingReceived = yVault.withdraw(_sharesToBurn, address(this), 1);
+        require(
+            underlyingReceived >= _minUnderlyingReceived,
+            Errors.Action_UnderlyingReceivedLessThanExpected(underlyingReceived, _minUnderlyingReceived)
+        );
     }
 
-    /// @inheritdoc ERC4626Withdraw
-    function _getMaxWithdraw(address vault) internal view virtual override returns (uint256) {
-        IYearnVault yVault = IYearnVault(vault);
-
-        uint256 shares = yVault.balanceOf(address(this));
-        if (shares == 0) return 0;
-
-        uint256 pricePerShare = yVault.pricePerShare();
-        uint256 decimals = yVault.decimals();
-        return (shares * pricePerShare) / 10 ** decimals;
+    function _getBalance(address _vaultAddress) internal view override returns (uint256) {
+        return IYearnVault(_vaultAddress).balanceOf(address(this));
     }
 
-    /// @inheritdoc ERC4626Withdraw
+    /// @inheritdoc ShareBasedWithdraw
     function protocolName() public pure override returns (string memory) {
         return "Yearn";
     }

--- a/tests/actions.ts
+++ b/tests/actions.ts
@@ -56,10 +56,9 @@ type WithdrawArgs =
         | 'SparkWithdraw'
         | 'AcrossWithdraw'
         | 'MorphoWithdraw'
-        | 'VesperWithdraw'
         | 'YearnWithdrawV3';
     })
-  | (ShareBasedWithdrawArgs & { type: 'NotionalV3Withdraw' | 'YearnWithdraw' });
+  | (ShareBasedWithdrawArgs & { type: 'NotionalV3Withdraw' | 'YearnWithdraw' | 'VesperWithdraw' });
 
 // Specific interfaces for each action type
 interface SupplyArgs extends BaseActionArgs {
@@ -242,11 +241,11 @@ export const actionDefaults: Record<string, ActionArgs> = {
     safeOperation: 1,
     poolAddress: tokenConfig.vaUSDC.address,
     feeBasis: 0,
-    amount: '0',
-    maxSharesBurned: ethers.MaxUint256.toString(),
+    sharesToBurn: '0',
+    minUnderlyingReceived: '0',
     encoding: {
       inputParams: ['bytes4', 'uint16', 'uint256', 'uint256'],
-      encodingVariables: ['poolId', 'feeBasis', 'amount', 'maxSharesBurned'],
+      encodingVariables: ['poolId', 'feeBasis', 'sharesToBurn', 'minUnderlyingReceived'],
     },
   },
   Curve3PoolSwap: {

--- a/tests/actions.ts
+++ b/tests/actions.ts
@@ -31,6 +31,37 @@ interface BaseActionArgs {
   debug?: boolean;
 }
 
+// Share-based withdraw specific args
+interface ShareBasedWithdrawArgs extends BaseActionArgs {
+  poolAddress?: string;
+  feeBasis?: number;
+  sharesToBurn?: string | BigInt;
+  minUnderlyingReceived?: string | BigInt;
+}
+
+// Standard ERC4626 withdraw args
+interface ERC4626WithdrawArgs extends BaseActionArgs {
+  poolAddress?: string;
+  feeBasis?: number;
+  amount?: string | BigInt;
+  maxSharesBurned?: string | BigInt;
+}
+
+// Union type for different withdraw implementations
+type WithdrawArgs =
+  | (ERC4626WithdrawArgs & {
+      type:
+        | 'FluidWithdraw'
+        | 'YearnWithdraw'
+        | 'ClearpoolWithdraw'
+        | 'SparkWithdraw'
+        | 'AcrossWithdraw'
+        | 'MorphoWithdraw'
+        | 'VesperWithdraw'
+        | 'YearnWithdrawV3';
+    })
+  | (ShareBasedWithdrawArgs & { type: 'NotionalV3Withdraw' });
+
 // Specific interfaces for each action type
 interface SupplyArgs extends BaseActionArgs {
   type:
@@ -47,23 +78,6 @@ interface SupplyArgs extends BaseActionArgs {
   feeBasis?: number;
   amount?: string | BigInt;
   minSharesReceived?: string | BigInt;
-}
-
-interface WithdrawArgs extends BaseActionArgs {
-  type:
-    | 'FluidWithdraw'
-    | 'YearnWithdraw'
-    | 'ClearpoolWithdraw'
-    | 'SparkWithdraw'
-    | 'AcrossWithdraw'
-    | 'MorphoWithdraw'
-    | 'VesperWithdraw'
-    | 'NotionalV3Withdraw'
-    | 'YearnWithdrawV3';
-  poolAddress?: string;
-  feeBasis?: number;
-  amount?: string | BigInt;
-  maxSharesBurned?: string | BigInt;
 }
 
 interface SwapArgs extends BaseActionArgs {
@@ -584,11 +598,11 @@ export const actionDefaults: Record<string, ActionArgs> = {
     safeOperation: 1,
     poolAddress: tokenConfig.pUSDC.address,
     feeBasis: 0,
-    amount: '0',
-    maxSharesBurned: ethers.MaxUint256.toString(),
+    sharesToBurn: '0',
+    minUnderlyingReceived: '0',
     encoding: {
       inputParams: ['bytes4', 'uint16', 'uint256', 'uint256'],
-      encodingVariables: ['poolId', 'feeBasis', 'amount', 'maxSharesBurned'],
+      encodingVariables: ['poolId', 'feeBasis', 'sharesToBurn', 'minUnderlyingReceived'],
     },
   },
 };

--- a/tests/actions.ts
+++ b/tests/actions.ts
@@ -52,7 +52,6 @@ type WithdrawArgs =
   | (ERC4626WithdrawArgs & {
       type:
         | 'FluidWithdraw'
-        | 'YearnWithdraw'
         | 'ClearpoolWithdraw'
         | 'SparkWithdraw'
         | 'AcrossWithdraw'
@@ -60,7 +59,7 @@ type WithdrawArgs =
         | 'VesperWithdraw'
         | 'YearnWithdrawV3';
     })
-  | (ShareBasedWithdrawArgs & { type: 'NotionalV3Withdraw' });
+  | (ShareBasedWithdrawArgs & { type: 'NotionalV3Withdraw' | 'YearnWithdraw' });
 
 // Specific interfaces for each action type
 interface SupplyArgs extends BaseActionArgs {
@@ -215,11 +214,11 @@ export const actionDefaults: Record<string, ActionArgs> = {
     safeOperation: 1,
     poolAddress: tokenConfig.USDC.pools.yearn,
     feeBasis: 0,
-    amount: '0',
-    maxSharesBurned: ethers.MaxUint256.toString(),
+    sharesToBurn: '0',
+    minUnderlyingReceived: '0',
     encoding: {
       inputParams: ['bytes4', 'uint16', 'uint256', 'uint256'],
-      encodingVariables: ['poolId', 'feeBasis', 'amount', 'maxSharesBurned'],
+      encodingVariables: ['poolId', 'feeBasis', 'sharesToBurn', 'minUnderlyingReceived'],
     },
   },
   VesperSupply: {

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -209,7 +209,7 @@ export const tokenConfig = {
   pUSDC: {
     address: '0xaEeAfB1259f01f363d09D7027ad80a9d442de762',
     whale: '0x2920F9Fc667E780C0CB5a78a104d21413377f97E',
-    decimals: 18,
+    decimals: 8,
   },
   yearnV3_DAI: {
     address: '0x92545bCE636E6eE91D88D2D017182cD0bd2fC22e',


### PR DESCRIPTION
Added a test to help check we deposit and withdraw appropriate amounts of underlying. This should help diagnose if we are mixing up underlying and share values.
Notional was withdrawing 1/100th the amount we requested. In resolving this I noticed that we really needed a share based withdraw pattern. Instead of specifying the underlying we want and checking the max shares burnt. We should be specifying the shares to burn and checking we receive a minimum amount of underlying. 
That new ShareBasedWithdraw pattern is implemented for Notional and YearnV1.