### PR TITLE
Implement BravaGuard to limit user transactions to approved contracts

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -27,6 +27,9 @@ contract Errors {
     error AdminVault_NotPool(address _pool);
     error AdminVault_AlreadyGranted();
     error AdminVault_NotGranted();
+    error AdminVault_TransactionNotProposed();
+    error AdminVault_TransactionAlreadyApproved();
+    error AdminVault_TransactionNotApproved(bytes32 txHash);
 
     // FeeTakeSafeModule errors
     error FeeTakeSafeModule_SenderNotFeeTaker(address _sender);

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -30,6 +30,7 @@ contract Errors {
     error AdminVault_TransactionNotProposed();
     error AdminVault_TransactionAlreadyApproved();
     error AdminVault_TransactionNotApproved(bytes32 txHash);
+    error AdminVault_MissingRole(bytes32 role, address account);
 
     // FeeTakeSafeModule errors
     error FeeTakeSafeModule_SenderNotFeeTaker(address _sender);

--- a/contracts/Logger.sol
+++ b/contracts/Logger.sol
@@ -32,7 +32,7 @@ contract Logger is ILogger, Initializable {
     // The logId initial digit is the type of event:
     // 1XX = Proposal, 2XX = Grant, 3XX = Cancel, 4XX = Removal
     // The next two digits are what category this permission change belongs to:
-    // 00 = DelayChange, 01 = Action, 02 = Pool, 03 = Fees, 04 = Role
+    // 00 = DelayChange, 01 = Action, 02 = Pool, 03 = Fees, 04 = Role, 05 = Transaction
     function logAdminVaultEvent(uint256 _logId, bytes memory _data) public {
         emit AdminVaultEvent(_logId, _data);
     }

--- a/contracts/auth/AdminVault.sol
+++ b/contracts/auth/AdminVault.sol
@@ -51,12 +51,6 @@ contract AdminVault is AccessControlDelayed, Multicall {
     /// The sequence executor is only given the actionId, so this mapping limits it to action addresses we've approved.
     mapping(bytes4 => address) public actionAddresses;
 
-    /// @notice Mapping of transaction hashes to their approval status
-    mapping(bytes32 => bool) public approvedTransactions;
-
-    /// @notice Mapping of transaction hashes to their proposal timestamps
-    mapping(bytes32 => uint256) public transactionProposals;
-
     /// @notice Initializes the AdminVault with an initial owner, delay period and logger.
     /// @param _initialOwner The address to be granted all initial
     /// @param _delay The required delay period for proposals (in seconds).
@@ -382,54 +376,9 @@ contract AdminVault is AccessControlDelayed, Multicall {
         return uint256(keccak256(abi.encode(_protocolName)));
     }
 
-    /// @notice Proposes a transaction for approval
-    /// @param _txHash The hash of the transaction to propose
-    function proposeTransaction(bytes32 _txHash) external onlyRole(TRANSACTION_PROPOSER_ROLE) {
-        require(_txHash != bytes32(0), Errors.InvalidInput("AdminVault", "proposeTransaction"));
-        require(!approvedTransactions[_txHash], Errors.AdminVault_TransactionAlreadyApproved());
-
-        transactionProposals[_txHash] = _getDelayTimestamp();
-        LOGGER.logAdminVaultEvent(105, abi.encode(_txHash));
-    }
-
-    /// @notice Cancels a transaction proposal
-    /// @param _txHash The hash of the transaction proposal to cancel
-    function cancelTransactionProposal(bytes32 _txHash) external onlyRole(TRANSACTION_CANCELER_ROLE) {
-        require(transactionProposals[_txHash] != 0, Errors.AdminVault_TransactionNotProposed());
-
-        delete transactionProposals[_txHash];
-        LOGGER.logAdminVaultEvent(305, abi.encode(_txHash));
-    }
-
-    /// @notice Approves a proposed transaction after the delay period
-    /// @param _txHash The hash of the transaction to approve
-    function approveTransaction(bytes32 _txHash) external onlyRole(TRANSACTION_EXECUTOR_ROLE) {
-        require(_txHash != bytes32(0), Errors.InvalidInput("AdminVault", "approveTransaction"));
-        require(!approvedTransactions[_txHash], Errors.AdminVault_TransactionAlreadyApproved());
-        require(transactionProposals[_txHash] != 0, Errors.AdminVault_TransactionNotProposed());
-        require(
-            block.timestamp >= transactionProposals[_txHash],
-            Errors.AdminVault_DelayNotPassed(block.timestamp, transactionProposals[_txHash])
-        );
-
-        delete transactionProposals[_txHash];
-        approvedTransactions[_txHash] = true;
-        LOGGER.logAdminVaultEvent(205, abi.encode(_txHash));
-    }
-
-    /// @notice Revokes an approved transaction
-    /// @param _txHash The hash of the transaction to revoke
-    function revokeTransaction(bytes32 _txHash) external onlyRole(TRANSACTION_DISPOSER_ROLE) {
-        require(approvedTransactions[_txHash], Errors.AdminVault_TransactionNotApproved(_txHash));
-
-        delete approvedTransactions[_txHash];
-        LOGGER.logAdminVaultEvent(405, abi.encode(_txHash));
-    }
-
-    /// @notice Checks if a transaction hash has been approved
-    /// @param _txHash The hash of the transaction to check
-    /// @return bool True if the transaction is approved
-    function isApprovedTransaction(bytes32 _txHash) external view returns (bool) {
-        return approvedTransactions[_txHash];
+    /// @notice Returns the delay period for proposals
+    /// @return The delay period in seconds
+    function DELAY() external view returns (uint256) {
+        return delay;
     }
 }

--- a/contracts/auth/AdminVault.sol
+++ b/contracts/auth/AdminVault.sol
@@ -377,8 +377,8 @@ contract AdminVault is AccessControlDelayed, Multicall {
     }
 
     /// @notice Returns the delay period for proposals
-    /// @return The delay period in seconds
-    function DELAY() external view returns (uint256) {
-        return delay;
+    /// @return The timestamp to wait until
+    function getDelayTimestamp() external returns (uint256) {
+        return _getDelayTimestamp();
     }
 }

--- a/contracts/auth/BravaGuard.sol
+++ b/contracts/auth/BravaGuard.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Enum} from "../libraries/Enum.sol";
+import {IBaseGuard} from "../interfaces/IBaseGuard.sol";
+import {IAdminVault} from "../interfaces/IAdminVault.sol";
+
+/**
+ * @title BravaGuard - A guard that enforces transaction rules and supports pre-approved admin operations
+ * @dev This guard ensures transactions either:
+ *      1. Are execTransaction/execTransactionFromModule calls with first destination being the sequenceExecutor, or
+ *      2. Match a pre-approved transaction hash in the AdminVault
+ */
+contract BravaGuard is IBaseGuard {
+    address public immutable SEQUENCE_EXECUTOR;
+    IAdminVault public immutable ADMIN_VAULT;
+
+    bytes4 private constant EXEC_TRANSACTION_SELECTOR = 0x6a761202;
+    bytes4 private constant EXEC_FROM_MODULE_SELECTOR = 0x468721a7;
+
+    event TransactionChecked(address indexed destination);
+
+    constructor(address _sequenceExecutor, address _adminVault) {
+        require(_sequenceExecutor != address(0), "Invalid executor address");
+        require(_adminVault != address(0), "Invalid admin vault address");
+        SEQUENCE_EXECUTOR = _sequenceExecutor;
+        ADMIN_VAULT = IAdminVault(_adminVault);
+    }
+
+    function getTransactionHash(address to, bytes memory data, Enum.Operation operation) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(to, data, operation));
+    }
+
+    function validateTransaction(address to, uint256, bytes memory data, Enum.Operation operation) private view {
+        bytes4 selector = bytes4(data);
+
+        if (selector == EXEC_TRANSACTION_SELECTOR || selector == EXEC_FROM_MODULE_SELECTOR) {
+            require(to == SEQUENCE_EXECUTOR, "First transaction must go to sequenceExecutor");
+            return;
+        }
+
+        bytes32 txHash = getTransactionHash(to, data, operation);
+        require(ADMIN_VAULT.isApprovedTransaction(txHash), "Transaction not allowed or pre-approved");
+    }
+
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
+    ) external override {
+        validateTransaction(to, value, data, operation);
+        emit TransactionChecked(to);
+    }
+
+    function checkAfterExecution(bytes32, bool) external override {}
+
+    function checkModuleTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        address
+    ) external override returns (bytes32) {
+        validateTransaction(to, value, data, operation);
+        emit TransactionChecked(to);
+        return getTransactionHash(to, data, operation);
+    }
+
+    function checkAfterModuleExecution(bytes32, bool) external override {}
+}

--- a/contracts/auth/BravaGuard.sol
+++ b/contracts/auth/BravaGuard.sol
@@ -32,11 +32,10 @@ contract BravaGuard is ITransactionGuard, IModuleGuard {
     }
 
     function getTransactionHash(
-        address to,
         bytes memory data,
         Enum.Operation operation
     ) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(to, data, operation));
+        return keccak256(abi.encodePacked(data, operation));
     }
 
     /// @dev Validates if a transaction is allowed to proceed
@@ -48,7 +47,7 @@ contract BravaGuard is ITransactionGuard, IModuleGuard {
         }
 
         // Check secondary path: pre-approved administrative operation
-        bytes32 txHash = getTransactionHash(to, data, operation);
+        bytes32 txHash = getTransactionHash(data, operation);
         require(ADMIN_VAULT.isApprovedTransaction(txHash), BravaGuard_TransactionNotAllowed());
     }
 
@@ -78,7 +77,7 @@ contract BravaGuard is ITransactionGuard, IModuleGuard {
         address
     ) external view override returns (bytes32) {
         validateTransaction(to, data, operation);
-        return getTransactionHash(to, data, operation);
+        return getTransactionHash(data, operation);
     }
 
     function checkAfterModuleExecution(bytes32, bool) external pure override {}

--- a/contracts/auth/BravaGuard.sol
+++ b/contracts/auth/BravaGuard.sol
@@ -5,47 +5,52 @@ import {Enum} from "../libraries/Enum.sol";
 import {IBaseGuard} from "../interfaces/IBaseGuard.sol";
 import {IAdminVault} from "../interfaces/IAdminVault.sol";
 
+/// @notice Found a vulnerability? Please contact security@bravalabs.xyz - we appreciate responsible disclosure and reward ethical hackers
 /**
- * @title BravaGuard - A guard that enforces transaction rules and supports pre-approved admin operations
- * @dev This guard ensures transactions either:
- *      1. Are execTransaction/execTransactionFromModule calls with first destination being the sequenceExecutor, or
- *      2. Match a pre-approved transaction hash in the AdminVault
+ * @title BravaGuard - A guard that enforces transaction rules with support for pre-approved admin operations
+ * @dev This guard ensures transactions follow one of two valid paths:
+ *      1. Normal Operations (Primary Path):
+ *         - Must target the sequenceExecutor
+ *         - All state-changing Safe operations will go through execTransaction/execTransactionFromModule
+ *      2. Administrative Operations (Secondary Path):
+ *         - For operations like guard upgrades, Safe upgrades, or other admin functions
+ *         - Transaction hash must be pre-approved in the AdminVault
+ *         - Allows users to perform verified administrative actions without central coordination
  */
 contract BravaGuard is IBaseGuard {
     address public immutable SEQUENCE_EXECUTOR;
     IAdminVault public immutable ADMIN_VAULT;
 
-    bytes4 private constant EXEC_TRANSACTION_SELECTOR = 0x6a761202;
-    bytes4 private constant EXEC_FROM_MODULE_SELECTOR = 0x468721a7;
-
-    event TransactionChecked(address indexed destination);
+    error BravaGuard_InvalidAddress();
+    error BravaGuard_TransactionNotAllowed();
 
     constructor(address _sequenceExecutor, address _adminVault) {
-        require(_sequenceExecutor != address(0), "Invalid executor address");
-        require(_adminVault != address(0), "Invalid admin vault address");
+        require(_sequenceExecutor != address(0) && _adminVault != address(0), BravaGuard_InvalidAddress());
         SEQUENCE_EXECUTOR = _sequenceExecutor;
         ADMIN_VAULT = IAdminVault(_adminVault);
     }
 
-    function getTransactionHash(address to, bytes memory data, Enum.Operation operation) public pure returns (bytes32) {
+    function getTransactionHash(address to, bytes memory data, Enum.Operation operation) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(to, data, operation));
     }
 
-    function validateTransaction(address to, uint256, bytes memory data, Enum.Operation operation) private view {
-        bytes4 selector = bytes4(data);
-
-        if (selector == EXEC_TRANSACTION_SELECTOR || selector == EXEC_FROM_MODULE_SELECTOR) {
-            require(to == SEQUENCE_EXECUTOR, "First transaction must go to sequenceExecutor");
+    /// @dev Validates if a transaction is allowed to proceed
+    /// @dev Reverts if the transaction is neither targeting the sequence executor nor pre-approved in the admin vault
+    function validateTransaction(address to, bytes memory data, Enum.Operation operation) private view {
+        // Check primary path: transaction to sequenceExecutor
+        if (to == SEQUENCE_EXECUTOR) {
             return;
         }
 
+        // Check secondary path: pre-approved administrative operation
         bytes32 txHash = getTransactionHash(to, data, operation);
-        require(ADMIN_VAULT.isApprovedTransaction(txHash), "Transaction not allowed or pre-approved");
+        require(ADMIN_VAULT.isApprovedTransaction(txHash), BravaGuard_TransactionNotAllowed());
     }
 
+    /// @inheritdoc IBaseGuard
     function checkTransaction(
         address to,
-        uint256 value,
+        uint256,
         bytes memory data,
         Enum.Operation operation,
         uint256,
@@ -55,24 +60,25 @@ contract BravaGuard is IBaseGuard {
         address payable,
         bytes memory,
         address
-    ) external override {
-        validateTransaction(to, value, data, operation);
-        emit TransactionChecked(to);
+    ) external view override {
+        validateTransaction(to, data, operation);
     }
 
-    function checkAfterExecution(bytes32, bool) external override {}
+    /// @inheritdoc IBaseGuard
+    function checkAfterExecution(bytes32, bool) external override pure {}
 
+    /// @inheritdoc IBaseGuard
     function checkModuleTransaction(
         address to,
-        uint256 value,
+        uint256,
         bytes memory data,
         Enum.Operation operation,
         address
-    ) external override returns (bytes32) {
-        validateTransaction(to, value, data, operation);
-        emit TransactionChecked(to);
+    ) external view override returns (bytes32) {
+        validateTransaction(to, data, operation);
         return getTransactionHash(to, data, operation);
     }
 
-    function checkAfterModuleExecution(bytes32, bool) external override {}
+    /// @inheritdoc IBaseGuard
+    function checkAfterModuleExecution(bytes32, bool) external override pure {}
 }

--- a/contracts/auth/Roles.sol
+++ b/contracts/auth/Roles.sol
@@ -54,6 +54,10 @@ abstract contract Roles {
     bytes32 public constant ACTION_CANCELER_ROLE = keccak256("ACTION_CANCELER_ROLE");
     bytes32 public constant ACTION_EXECUTOR_ROLE = keccak256("ACTION_EXECUTOR_ROLE");
     bytes32 public constant ACTION_DISPOSER_ROLE = keccak256("ACTION_DISPOSER_ROLE");
+    bytes32 public constant TRANSACTION_PROPOSER_ROLE = keccak256("TRANSACTION_PROPOSER_ROLE");
+    bytes32 public constant TRANSACTION_CANCELER_ROLE = keccak256("TRANSACTION_CANCELER_ROLE");
+    bytes32 public constant TRANSACTION_EXECUTOR_ROLE = keccak256("TRANSACTION_EXECUTOR_ROLE");
+    bytes32 public constant TRANSACTION_DISPOSER_ROLE = keccak256("TRANSACTION_DISPOSER_ROLE");
 
     // FEE_TAKER_ROLE is the role that can trigger the fee taking mechanism
     bytes32 public constant FEE_TAKER_ROLE = keccak256("FEE_TAKER_ROLE");

--- a/contracts/auth/TransactionRegistry.sol
+++ b/contracts/auth/TransactionRegistry.sol
@@ -42,8 +42,8 @@ contract TransactionRegistry is Multicall, Roles {
     }
 
     /// @notice Gets the delay timestamp from AdminVault
-    function _getDelayTimestamp() internal view returns (uint256) {
-        return block.timestamp + ADMIN_VAULT.DELAY();
+    function _getDelayTimestamp() internal returns (uint256) {
+        return ADMIN_VAULT.getDelayTimestamp();
     }
 
     /// @notice Proposes a transaction for approval

--- a/contracts/auth/TransactionRegistry.sol
+++ b/contracts/auth/TransactionRegistry.sol
@@ -37,7 +37,9 @@ contract TransactionRegistry is Multicall, Roles {
 
     /// @notice Modifier to check if caller has a specific role
     modifier onlyRole(bytes32 role) {
-        require(ADMIN_VAULT.hasRole(role, msg.sender), "TransactionRegistry: missing role");
+        if (!ADMIN_VAULT.hasRole(role, msg.sender)) {
+            revert Errors.AdminVault_MissingRole(role, msg.sender);
+        }
         _;
     }
 

--- a/contracts/auth/TransactionRegistry.sol
+++ b/contracts/auth/TransactionRegistry.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {Errors} from "../Errors.sol";
+import {Multicall} from "@openzeppelin/contracts/utils/Multicall.sol";
+import {ILogger} from "../interfaces/ILogger.sol";
+import {IAdminVault} from "../interfaces/IAdminVault.sol";
+import {Roles} from "./Roles.sol";
+
+/// @title TransactionRegistry
+/// @notice Manages transaction approvals with a delay mechanism
+/// @author BravaLabs.xyz
+contract TransactionRegistry is Multicall, Roles {
+    /// @notice The AdminVault contract that manages permissions
+    IAdminVault public immutable ADMIN_VAULT;
+    
+    /// @notice The Logger contract for events
+    ILogger public immutable LOGGER;
+
+    /// @notice Mapping of transaction hashes to their approval status
+    mapping(bytes32 => bool) public approvedTransactions;
+
+    /// @notice Mapping of transaction hashes to their proposal timestamps
+    mapping(bytes32 => uint256) public transactionProposals;
+
+    /// @notice Initializes the TransactionRegistry
+    /// @param _adminVault The address of the AdminVault contract
+    /// @param _logger The address of the Logger contract
+    constructor(address _adminVault, address _logger) {
+        require(
+            _adminVault != address(0) && _logger != address(0), 
+            Errors.InvalidInput("TransactionRegistry", "constructor")
+        );
+        ADMIN_VAULT = IAdminVault(_adminVault);
+        LOGGER = ILogger(_logger);
+    }
+
+    /// @notice Modifier to check if caller has a specific role
+    modifier onlyRole(bytes32 role) {
+        require(ADMIN_VAULT.hasRole(role, msg.sender), "TransactionRegistry: missing role");
+        _;
+    }
+
+    /// @notice Gets the delay timestamp from AdminVault
+    function _getDelayTimestamp() internal view returns (uint256) {
+        return block.timestamp + ADMIN_VAULT.DELAY();
+    }
+
+    /// @notice Proposes a transaction for approval
+    /// @param _txHash The hash of the transaction to propose
+    function proposeTransaction(bytes32 _txHash) external onlyRole(Roles.TRANSACTION_PROPOSER_ROLE) {
+        require(_txHash != bytes32(0), Errors.InvalidInput("TransactionRegistry", "proposeTransaction"));
+        require(!approvedTransactions[_txHash], Errors.AdminVault_TransactionAlreadyApproved());
+
+        transactionProposals[_txHash] = _getDelayTimestamp();
+        LOGGER.logAdminVaultEvent(105, abi.encode(_txHash));
+    }
+
+    /// @notice Cancels a transaction proposal
+    /// @param _txHash The hash of the transaction proposal to cancel
+    function cancelTransactionProposal(bytes32 _txHash) external onlyRole(Roles.TRANSACTION_CANCELER_ROLE) {
+        require(transactionProposals[_txHash] != 0, Errors.AdminVault_TransactionNotProposed());
+
+        delete transactionProposals[_txHash];
+        LOGGER.logAdminVaultEvent(305, abi.encode(_txHash));
+    }
+
+    /// @notice Approves a proposed transaction after the delay period
+    /// @param _txHash The hash of the transaction to approve
+    function approveTransaction(bytes32 _txHash) external onlyRole(Roles.TRANSACTION_EXECUTOR_ROLE) {
+        require(_txHash != bytes32(0), Errors.InvalidInput("TransactionRegistry", "approveTransaction"));
+        require(!approvedTransactions[_txHash], Errors.AdminVault_TransactionAlreadyApproved());
+        require(transactionProposals[_txHash] != 0, Errors.AdminVault_TransactionNotProposed());
+        require(
+            block.timestamp >= transactionProposals[_txHash],
+            Errors.AdminVault_DelayNotPassed(block.timestamp, transactionProposals[_txHash])
+        );
+
+        delete transactionProposals[_txHash];
+        approvedTransactions[_txHash] = true;
+        LOGGER.logAdminVaultEvent(205, abi.encode(_txHash));
+    }
+
+    /// @notice Revokes an approved transaction
+    /// @param _txHash The hash of the transaction to revoke
+    function revokeTransaction(bytes32 _txHash) external onlyRole(Roles.TRANSACTION_DISPOSER_ROLE) {
+        require(approvedTransactions[_txHash], Errors.AdminVault_TransactionNotApproved(_txHash));
+
+        delete approvedTransactions[_txHash];
+        LOGGER.logAdminVaultEvent(405, abi.encode(_txHash));
+    }
+
+    /// @notice Checks if a transaction hash has been approved
+    /// @param _txHash The hash of the transaction to check
+    /// @return bool True if the transaction is approved
+    function isApprovedTransaction(bytes32 _txHash) external view returns (bool) {
+        return approvedTransactions[_txHash];
+    }
+} 

--- a/contracts/interfaces/IAdminVault.sol
+++ b/contracts/interfaces/IAdminVault.sol
@@ -73,5 +73,5 @@ interface IAdminVault {
     function isApprovedTransaction(bytes32 txHash) external view returns (bool);
 
     // Delay Management Functions
-    function DELAY() external view returns (uint256);
+    function getDelayTimestamp() external returns (uint256);
 }

--- a/contracts/interfaces/IAdminVault.sol
+++ b/contracts/interfaces/IAdminVault.sol
@@ -71,4 +71,7 @@ interface IAdminVault {
     function approveTransaction(bytes32 txHash) external;
     function revokeTransaction(bytes32 txHash) external;
     function isApprovedTransaction(bytes32 txHash) external view returns (bool);
+
+    // Delay Management Functions
+    function DELAY() external view returns (uint256);
 }

--- a/contracts/interfaces/IAdminVault.sol
+++ b/contracts/interfaces/IAdminVault.sol
@@ -64,4 +64,11 @@ interface IAdminVault {
     function cancelActionProposal(bytes4 actionId, address actionAddress) external;
     function addAction(bytes4 actionId, address actionAddress) external;
     function removeAction(bytes4 actionId) external;
+
+    // Transaction Management Functions
+    function proposeTransaction(bytes32 txHash) external;
+    function cancelTransactionProposal(bytes32 txHash) external;
+    function approveTransaction(bytes32 txHash) external;
+    function revokeTransaction(bytes32 txHash) external;
+    function isApprovedTransaction(bytes32 txHash) external view returns (bool);
 }

--- a/contracts/interfaces/IBaseGuard.sol
+++ b/contracts/interfaces/IBaseGuard.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Enum} from "../libraries/Enum.sol";
+
+interface IBaseGuard {
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external;
+    
+    function checkModuleTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        address module
+    ) external returns (bytes32);
+    
+    function checkAfterModuleExecution(bytes32 txHash, bool success) external;
+} 

--- a/contracts/interfaces/safe/IGuard.sol
+++ b/contracts/interfaces/safe/IGuard.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Enum} from "../../libraries/Enum.sol";
+
+interface ITransactionGuard {
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external view;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external view;
+}
+
+interface IModuleGuard {
+    function checkModuleTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        address module
+    ) external view returns (bytes32);
+
+    function checkAfterModuleExecution(bytes32 txHash, bool success) external view;
+} 

--- a/tests/auth/BravaGuard.test.ts
+++ b/tests/auth/BravaGuard.test.ts
@@ -1,0 +1,257 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import {
+  deploy,
+  encodeAction,
+  executeAction,
+  executeSequence,
+  getBaseSetup,
+  getBytes4,
+} from '../utils';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import {
+  BravaGuard,
+  TransactionRegistry,
+  SequenceExecutor,
+  AdminVault,
+  Logger,
+} from '../../typechain-types';
+import { ISafe } from '../../typechain-types/contracts/interfaces/safe/ISafe';
+import { tokenConfig } from '../constants';
+import { fundAccountWithToken } from '../utils-stable';
+
+// Operation enum from the contract
+enum Operation {
+  Call,
+  DelegateCall,
+}
+
+// Helper function to generate role bytes
+function getRoleBytes(role: string): string {
+  return ethers.keccak256(ethers.toUtf8Bytes(role));
+}
+
+// Helper function to create Safe signature
+function createSafeSignature(signer: SignerWithAddress): string {
+  return (
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ['address', 'bytes32'],
+      [signer.address, ethers.ZeroHash]
+    ) + '01'
+  );
+}
+
+// Helper function to calculate transaction hash
+function calculateTransactionHash(
+  to: string,
+  data: string,
+  operation: Operation
+): string {
+  return ethers.keccak256(
+    ethers.solidityPacked(
+      ['address', 'bytes', 'uint8'],
+      [to, data, operation]
+    )
+  );
+}
+
+describe('BravaGuard', () => {
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let bravaGuard: BravaGuard;
+  let transactionRegistry: TransactionRegistry;
+  let sequenceExecutor: SequenceExecutor;
+  let adminVault: AdminVault;
+  let safe: ISafe;
+  let logger: Logger;
+  beforeEach(async () => {
+    [deployer, user] = await ethers.getSigners();
+
+    // Get base setup with AdminVault
+    const baseSetup = await getBaseSetup(deployer);
+    if (!baseSetup) {
+      throw new Error('Base setup not deployed');
+    }
+    adminVault = baseSetup.adminVault;
+    safe = baseSetup.safe;
+    logger = baseSetup.logger;
+    sequenceExecutor = baseSetup.sequenceExecutor;
+
+    // Deploy additional contracts
+    transactionRegistry = await deploy<TransactionRegistry>(
+      'TransactionRegistry',
+      deployer,
+      await adminVault.getAddress(),
+      await logger.getAddress()
+    );
+    bravaGuard = await deploy<BravaGuard>(
+      'BravaGuard',
+      deployer,
+      await sequenceExecutor.getAddress(),
+      await transactionRegistry.getAddress()
+    );
+
+    // Set guard on Safe through execTransaction
+    const setGuardData = safe.interface.encodeFunctionData('setGuard', [
+      await bravaGuard.getAddress(),
+    ]);
+    const signature = createSafeSignature(deployer);
+
+    await safe.execTransaction(
+      await safe.getAddress(),
+      0,
+      setGuardData,
+      Operation.Call,
+      0,
+      0,
+      0,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      signature
+    );
+  });
+
+  describe('Deployment', () => {
+    it('should deploy with correct addresses', async () => {
+      expect(await bravaGuard.SEQUENCE_EXECUTOR()).to.equal(await sequenceExecutor.getAddress());
+      expect(await bravaGuard.ADMIN_VAULT()).to.equal(await transactionRegistry.getAddress());
+    });
+
+    it('should revert deployment with zero addresses', async () => {
+      const BravaGuard = await ethers.getContractFactory('BravaGuard');
+      await expect(
+        BravaGuard.deploy(ethers.ZeroAddress, await transactionRegistry.getAddress())
+      ).to.be.revertedWithCustomError(bravaGuard, 'BravaGuard_InvalidAddress');
+      await expect(
+        BravaGuard.deploy(await sequenceExecutor.getAddress(), ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(bravaGuard, 'BravaGuard_InvalidAddress');
+    });
+  });
+
+  describe('Transaction Validation', () => {
+    it('should allow transactions to sequence executor', async () => {
+      const fluidSupplyContract = await deploy(
+        'FluidSupply',
+        deployer,
+        await adminVault.getAddress(),
+        await logger.getAddress()
+      );
+      const fluidSupplyAddress = await fluidSupplyContract.getAddress();
+      await adminVault.proposeAction(getBytes4(fluidSupplyAddress), fluidSupplyAddress);
+      await adminVault.addAction(getBytes4(fluidSupplyAddress), fluidSupplyAddress);
+      await adminVault.proposePool('Fluid', tokenConfig.fUSDC.address);
+      await adminVault.addPool('Fluid', tokenConfig.fUSDC.address);
+
+      const token = 'USDC';
+      const amount = ethers.parseUnits('100', tokenConfig[token].decimals);
+      await fundAccountWithToken(await safe.getAddress(), token, amount);
+
+      const payload = await encodeAction({
+        type: 'FluidSupply',
+        amount,
+      });
+
+      await executeSequence(await safe.getAddress(), {
+        name: 'FluidSupplySequence',
+        callData: [payload],
+        actionIds: [getBytes4(fluidSupplyAddress)],
+      }, false);
+      
+    });
+
+    it('should allow pre-approved admin transactions', async () => {
+      const tx = {
+        to: await safe.getAddress(),
+        value: 0,
+        data: safe.interface.encodeFunctionData('setGuard', [ethers.ZeroAddress]),
+        operation: Operation.Call,
+        safeTxGas: 0,
+        baseGas: 0,
+        gasPrice: 0,
+        gasToken: ethers.ZeroAddress,
+        refundReceiver: ethers.ZeroAddress,
+      };
+
+      const signature = createSafeSignature(deployer);
+
+      // Should fail because this is not a pre-approved transaction
+      await expect(
+        safe.execTransaction(
+          tx.to,
+          tx.value,
+          tx.data,
+          tx.operation,
+          tx.safeTxGas,
+          tx.baseGas,
+          tx.gasPrice,
+          tx.gasToken,
+          tx.refundReceiver,
+          signature
+        )
+      ).to.be.revertedWithCustomError(bravaGuard, 'BravaGuard_TransactionNotAllowed');
+
+      const txHash = calculateTransactionHash(tx.to, tx.data, tx.operation);
+
+      // Propose and approve the transaction with delay
+      await transactionRegistry.proposeTransaction(txHash);
+
+      // Increase time to pass the delay period
+      const delay = await adminVault.DELAY();
+      await ethers.provider.send('evm_increaseTime', [Number(delay)]);
+      await ethers.provider.send('evm_mine', []);
+
+      await transactionRegistry.approveTransaction(txHash);
+
+      const isApproved = await transactionRegistry.isApprovedTransaction(txHash);
+      expect(isApproved).to.be.true;
+
+
+      // Should now succeed because the transaction is pre-approved
+      await expect(
+        safe.execTransaction(
+          tx.to,
+          tx.value,
+          tx.data,
+          tx.operation,
+          tx.safeTxGas,
+          tx.baseGas,
+          tx.gasPrice,
+          tx.gasToken,
+          tx.refundReceiver,
+          signature
+        )
+      ).to.not.be.reverted;
+    });
+
+    it('should block unauthorized transactions', async () => {
+      const tx = {
+        to: await user.getAddress(),
+        value: 0,
+        data: '0x',
+        operation: Operation.Call,
+        safeTxGas: 0,
+        baseGas: 0,
+        gasPrice: 0,
+        gasToken: ethers.ZeroAddress,
+        refundReceiver: ethers.ZeroAddress,
+      };
+
+      const signature = createSafeSignature(deployer);
+
+      await expect(
+        safe.execTransaction(
+          tx.to,
+          tx.value,
+          tx.data,
+          tx.operation,
+          tx.safeTxGas,
+          tx.baseGas,
+          tx.gasPrice,
+          tx.gasToken,
+          tx.refundReceiver,
+          signature
+        )
+      ).to.be.revertedWithCustomError(bravaGuard, 'BravaGuard_TransactionNotAllowed');
+    });
+  });
+});

--- a/tests/auth/BravaGuard.test.ts
+++ b/tests/auth/BravaGuard.test.ts
@@ -192,14 +192,8 @@ describe('BravaGuard', () => {
 
       const txHash = calculateTransactionHash(tx.to, tx.data, tx.operation);
 
-      // Propose and approve the transaction with delay
+      // Propose and approve the transaction (testing delay is zero)
       await transactionRegistry.proposeTransaction(txHash);
-
-      // Increase time to pass the delay period
-      const delay = await adminVault.DELAY();
-      await ethers.provider.send('evm_increaseTime', [Number(delay)]);
-      await ethers.provider.send('evm_mine', []);
-
       await transactionRegistry.approveTransaction(txHash);
 
       const isApproved = await transactionRegistry.isApprovedTransaction(txHash);

--- a/tests/auth/FeeTakeSafeModule.test.ts
+++ b/tests/auth/FeeTakeSafeModule.test.ts
@@ -47,8 +47,8 @@ describe('FeeTakeSafeModule', function () {
     logger = baseSetup.logger;
     safe = baseSetup.safe;
     safeAddr = await safe.getAddress();
+    sequenceExecutor = baseSetup.sequenceExecutor;
 
-    sequenceExecutor = await deploy('SequenceExecutor', admin, await adminVault.getAddress());
     // Deploy FeeTakeSafeModule
     feeTakeSafeModule = await deploy(
       'FeeTakeSafeModule',

--- a/tests/sequence.test.ts
+++ b/tests/sequence.test.ts
@@ -33,8 +33,7 @@ describe('Sequence tests', () => {
     safeAddr = await baseSetup.safe.getAddress();
     adminVault = await baseSetup.adminVault;
     loggerAddress = await baseSetup.logger.getAddress();
-
-    sequenceExecutor = await deploy('SequenceExecutor', signer, await adminVault.getAddress());
+    sequenceExecutor = baseSetup.sequenceExecutor;
 
     // we need a couple of actions to test with
     fluidSupplyAction = await deploy(

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -31,6 +31,7 @@ import {
 export const isLoggingEnabled = process.env.ENABLE_LOGGING === 'true';
 export const USE_BRAVA_SDK = process.env.USE_BRAVA_SDK === 'true';
 
+export { deploySafe };
 export function log(...args: unknown[]): void {
   if (isLoggingEnabled) {
     console.log(...args);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -247,6 +247,7 @@ type BaseSetup = {
   safeProxyFactory: ISafeProxyFactory;
   safe: ISafe;
   signer: Signer;
+  sequenceExecutor: SequenceExecutor;
 };
 
 export async function deployBaseSetup(signer?: Signer): Promise<BaseSetup> {
@@ -266,8 +267,9 @@ export async function deployBaseSetup(signer?: Signer): Promise<BaseSetup> {
   );
   const safeAddress = await deploySafe(deploySigner, await safeProxyFactory.getAddress());
   const safe = await ethers.getContractAt('ISafe', safeAddress);
+  const sequenceExecutor = await deploy<SequenceExecutor>('SequenceExecutor', deploySigner, await adminVault.getAddress());
   log('Safe deployed at:', safeAddress);
-  return { logger, adminVault, safeProxyFactory, safe, signer: deploySigner };
+  return { logger, adminVault, safeProxyFactory, safe, signer: deploySigner, sequenceExecutor };
 }
 
 let baseSetupCache: Awaited<ReturnType<typeof deployBaseSetup>> | null = null;


### PR DESCRIPTION
Create a guard to add to user Safes.
The guard has 2 execution paths,

1. Transactions must go 'to' the SequenceExecutor
2. Transaction hash must be approved in the TransactionRegistry

The AdminVault hit the size limit, so TransactionRegistry is a separate contract that is deployed after and connected to the AdminVault. It checks with the AdminVault for permissions and delay timestamps. It stores proposals and approved transaction hashes for the BravaGuard.

TODO: The guard needs to be applied on safe creation. If not, a window exists where a malicious fallback handler could be applied that may bypass the guards protections. When this is implemented almost ALL the current tests will need to be updated to run through the sequenceExecutor (instead of individual action calls as currently implemented).