### PR TITLE
Sigma - Paraswap audit fixes

### DIFF
--- a/contracts/actions/swap/ParaswapSwap.sol
+++ b/contracts/actions/swap/ParaswapSwap.sol
@@ -22,7 +22,7 @@ contract ParaswapSwap is ActionBase {
 
     /// @notice Function selector for swapExactAmountIn (0xe3ead59e)
     /// @dev Used in Augustus Router's swapExactAmountIn function:
-    /// function swapExactAmountIn(address tokenIn, address tokenOut, uint256 amountIn, uint256 minAmountOut, ...)
+    /// function swapExactAmountIn(address executor, struct swapData, uint256 partnerAndFee, bytes permit, bytes executorData,)
     bytes4 public constant SWAP_EXACT_AMOUNT_IN_SELECTOR = 0xe3ead59e;
     
     /// @notice Function selector for swapExactAmountInOnUniswapV3 (0x876a02f6)


### PR DESCRIPTION
Sigma raised 2 informational issues in the audit of the Paraswap (now Velora) contracts. This PR fixes one of them.
 - Changed function comments to show the correct function types
 - The issue about potential for an incorrect address I think we will acknowledge, we check it's a non-zero address, so at least some address must have been provided. The proposed resolution to check that code exists at the address doesn't mean it checks the correct code exists. I'm not sure it's worth going down this road for a minor problem and we should simply be more careful during deployment.