### PR TITLE
Publish audited contracts @ a1907f3

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ Detailed technical documentation is available in [`contracts/docs/`](contracts/d
 
 ## Security Audits
 
-Previous audit reports by [Sigma Prime](https://sigmaprime.io/):
+Audit reports by [Sigma Prime](https://sigmaprime.io/):
 
 - [Core Protocol Audit](https://github.com/sigp/public-audits/blob/master/reports/brava/report.pdf)
 - [Module Integrations Add-on Audit](https://github.com/sigp/public-audits/blob/master/reports/brava/module-integrations/report.pdf)
+- [Core Auth Changes Audit](https://github.com/sigp/public-audits/blob/master/reports/brava/core-auth/Sigma_Prime_Brava_Core_Auth_Changes_Security_Assessment_Report_v3_0.pdf)
 
 See the [`audits/`](audits/) directory for full details. We prioritize security and transparency, working with leading audit firms to ensure the safety of user funds.
 

--- a/audits/README.md
+++ b/audits/README.md
@@ -21,7 +21,7 @@ Follow-up audit covering additional protocol integrations added after the core a
 Follow-up audit of the authentication and execution changes: the EIP-712 typed-data Safe module, AuthRegistry, CCTP bundle relay, emergency withdrawals, and the gas refund system, plus an LLM-assisted scan of the full codebase.
 
 - [View Report (PDF)](https://github.com/sigp/public-audits/blob/master/reports/brava/core-auth/Sigma_Prime_Brava_Core_Auth_Changes_Security_Assessment_Report_v3_0.pdf)
-- Assessed commits: cycle 1 at `01d8274`, cycle 2 at `017f1345` (an audit-time source snapshot, preserved on the `audit/core-auth-cycle2-snapshot` branch), and resolutions at `826d0ab`. All resolution commits cited in the report are on `main`.
+- Assessed commits: cycle 1 at `01d8274`, cycle 2 at `017f1345` (an audit-time source snapshot, pinned by the `audit/core-auth-cycle2` tag), and resolutions at `826d0ab`. All resolution commits cited in the report are on `main`.
 
 ## Upcoming
 

--- a/audits/README.md
+++ b/audits/README.md
@@ -21,7 +21,7 @@ Follow-up audit covering additional protocol integrations added after the core a
 Follow-up audit of the authentication and execution changes: the EIP-712 typed-data Safe module, AuthRegistry, CCTP bundle relay, emergency withdrawals, and the gas refund system, plus an LLM-assisted scan of the full codebase.
 
 - [View Report (PDF)](https://github.com/sigp/public-audits/blob/master/reports/brava/core-auth/Sigma_Prime_Brava_Core_Auth_Changes_Security_Assessment_Report_v3_0.pdf)
-- Assessed commits: cycle 1 at `01d8274`, cycle 2 at `017f1345` (an audit-time source snapshot, pinned by the `audit/core-auth-cycle2` tag), and resolutions at `826d0ab`. All resolution commits cited in the report are on `main`.
+- Assessed commits: cycle 1 at `01d8274`, cycle 2 at `017f1345` (an audit-time source snapshot that predates this repository's history), and resolutions at `826d0ab`. All resolution commits cited in the report are on `main`.
 
 ## Upcoming
 

--- a/audits/README.md
+++ b/audits/README.md
@@ -16,6 +16,13 @@ Follow-up audit covering additional protocol integrations added after the core a
 
 - [View Report (PDF)](https://github.com/sigp/public-audits/blob/master/reports/brava/module-integrations/report.pdf)
 
+### Sigma Prime -- Core Auth Changes Audit
+
+Follow-up audit of the authentication and execution changes: the EIP-712 typed-data Safe module, AuthRegistry, CCTP bundle relay, emergency withdrawals, and the gas refund system, plus an LLM-assisted scan of the full codebase.
+
+- [View Report (PDF)](https://github.com/sigp/public-audits/blob/master/reports/brava/core-auth/Sigma_Prime_Brava_Core_Auth_Changes_Security_Assessment_Report_v3_0.pdf)
+- Assessed commits: cycle 1 at `01d8274`, cycle 2 at `017f1345` (an audit-time source snapshot, preserved on the `audit/core-auth-cycle2-snapshot` branch), and resolutions at `826d0ab`. All resolution commits cited in the report are on `main`.
+
 ## Upcoming
 
 Further audit reports will be linked here as they are completed and approved for public release.

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -67,6 +67,7 @@ contract Errors {
     error Paraswap__InsufficientOutput(uint256 _amountReceived, uint256 _minToAmount);
     error Paraswap__TokenNotApproved(address token);
     error Paraswap__TokenMismatch(address expected, address actual);
+    error Paraswap__SourceTokenMismatch(address expected, address actual);
     error Paraswap__InvalidCalldata();
     error Paraswap__UnsupportedSelector(bytes4 selector);
 

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -95,7 +95,6 @@ contract Errors {
     error EIP712TypedDataSafeModule_ActionMismatch(uint256 actionIndex, string expectedProtocol, uint8 expectedType, string actualProtocol, uint8 actualType);
     error EIP712TypedDataSafeModule_ExecutionFailed();
     error EIP712TypedDataSafeModule_SignerNotAuthorised(address signer);
-    error EIP712TypedDataSafeModule_OnlyOwnerCanUpdateAuth(address lowestSigner);
     error EIP712TypedDataSafeModule_InsufficientCoSignatures(uint256 provided, uint256 required);
     error EIP712TypedDataSafeModule_DuplicateSigner(address signer);
     error EIP712TypedDataSafeModule_SignersNotSorted();
@@ -123,8 +122,8 @@ contract Errors {
     error TokenRegistry_TokenNotApproved();
 
     // AuthRegistry errors
-    error AuthRegistry_NotEnabledModule(address safe, address caller);
     error AuthRegistry_StaleVersion(uint256 provided, uint256 current);
+    error AuthRegistry_VersionJumpTooLarge(uint256 current, uint256 provided, uint256 maxIncrease);
     error AuthRegistry_ConflictingConfig(uint256 version);
     error AuthRegistry_TooManyManagers(uint256 count, uint256 max);
     error AuthRegistry_TooManyCoSigners(uint256 count, uint256 max);
@@ -135,27 +134,27 @@ contract Errors {
     error AuthRegistry_CoSignerIsManager(address addr);
     error AuthRegistry_RestrictionForNonManager(address manager);
     error AuthRegistry_EmptyRestriction(address manager);
-    error AuthRegistry_BitmapLengthMismatch(uint256 managersLength, uint256 bitmapsLength);
     error AuthRegistry_DuplicateRestriction(address manager);
-    error AuthRegistry_CCTPRelayFailed();
-    error AuthRegistry_BadHookEnvelope();
-    error AuthRegistry_UnknownHookVersion(uint8 version);
-    error AuthRegistry_HookSafeMismatch(bytes32 burnSender, bytes32 mintRecipient, address hookSafe);
-    error AuthRegistry_HookMessageTooShort();
-    error AuthRegistry_SafeMintRecipientMismatch(address safe, bytes32 mintRecipient);
-    error AuthRegistry_SafeOwnerMismatch(address safe, address ownerAddress, address predicted);
     error AuthRegistry_VersionZero();
+    error AuthRegistry_BundleExpired();
+    error AuthRegistry_InvalidSignatureLength(uint256 length);
+    error AuthRegistry_SignerNotOwner(address safe, address signer);
 
     // CCTPBundleReceiver errors
     error CCTPReceiver_BadMessage();
     error CCTPReceiver_BadVersion(uint32 provided);
+    error CCTPReceiver_BadBurnVersion(uint32 provided);
+    error CCTPReceiver_UntrustedSender(bytes32 sender);
+    error CCTPReceiver_UntrustedRecipient(bytes32 recipient);
     error CCTPReceiver_RelayFailed();
     error CCTPReceiver_ShortHook();
     error CCTPReceiver_OutOfBounds();
+    error CCTPReceiver_SafeMintRecipientMismatch(address safe, bytes32 mintRecipient);
 
     // CCTPBridgeSend errors
     error CCTPBridgeSend_InsufficientBalance(uint256 balance, uint256 amount);
     error CCTPBridgeSend_BalanceMismatch(uint256 beforeBalance, uint256 afterBalance, uint256 expectedDelta);
+    error CCTPBridgeSend_UnexpectedToken(address provided, address expected);
 
     // BravaModuleLookup errors
     error MultipleBravaModules(address first, address second);

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -79,6 +79,9 @@ contract Errors {
     // SendToken errors
     error Action_InvalidRecipient(string _protocolName, uint8 _actionType);
 
+    // PullToken errors
+    error PullToken__OnlyDelegateCall();
+
     // UpgradeAction errors
 
     // EIP712TypedDataSafeModule errors

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -84,6 +84,9 @@ contract Errors {
 
     // UpgradeAction errors
 
+    // SequenceExecutor errors
+    error SequenceExecutor_ActionReverted(uint256 actionIndex, bytes4 actionId, bytes reason);
+
     // EIP712TypedDataSafeModule errors
     error EIP712TypedDataSafeModule_InvalidSignature();
     error EIP712TypedDataSafeModule_BundleExpired();

--- a/contracts/Logger.sol
+++ b/contracts/Logger.sol
@@ -4,11 +4,24 @@ pragma solidity =0.8.28;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
+/// @title Logger
+/// @notice Central event hub for the Brava protocol. Emits structured events
+///         consumed by off-chain indexers and the security screener.
+/// @dev Every event carries its emitter as `caller` (msg.sender). The contract
+///      is permissionless; consumers establish trust by filtering events on
+///      `caller`, so the Logger needs no privileged maintenance surface.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract Logger is Initializable {
-    /// @notice Events to match the ILogger interface
+    /// @notice Emitted by action contracts (delegatecalled from user Safes, so `caller` is the Safe)
     event ActionEvent(address caller, uint8 logId, bytes data);
-    event AdminVaultEvent(uint256 logId, bytes data);
+
+    /// @notice Emitted by admin/governance contracts; `caller` identifies the emitting contract
+    event AdminVaultEvent(address caller, uint256 logId, bytes data);
+
+    /// @dev Storage slots occupied by the live proxy's prior caller whitelist.
+    ///      Retained unused so proxy upgrades preserve the existing layout.
+    address private _reservedSlot0;
+    mapping(address => bool) private _reservedSlot1;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -28,15 +41,16 @@ contract Logger is Initializable {
         emit ActionEvent(msg.sender, _logType, _data);
     }
 
-    /// @notice Logs an event from the AdminVault
+    /// @notice Logs an event from an admin/governance contract
     /// @param _logId The ID of the log
     /// @param _data The data to log
     /// @dev These events are important, they will be a permission change.
-    // The logId initial digit is the type of event:
-    // 1XX = Proposal, 2XX = Grant, 3XX = Cancel, 4XX = Removal
-    // The next two digits are what category this permission change belongs to:
-    // 00 = DelayChange, 01 = Action, 02 = Pool, 03 = Fees, 04 = Role, 05 = Transaction
+    ///      The logId initial digit is the type of event:
+    ///      1XX = Proposal, 2XX = Grant, 3XX = Cancel, 4XX = Removal
+    ///      The next two digits are what category this permission change belongs to:
+    ///      00 = DelayChange, 01 = Action, 02 = Pool, 03 = Fees, 04 = Role,
+    ///      05 = Transaction/Config, 06 = Token, 07 = SafeSetup, 08 = SafeDeploy
     function logAdminVaultEvent(uint256 _logId, bytes memory _data) public {
-        emit AdminVaultEvent(_logId, _data);
+        emit AdminVaultEvent(msg.sender, _logId, _data);
     }
 }

--- a/contracts/SequenceExecutor.sol
+++ b/contracts/SequenceExecutor.sol
@@ -74,50 +74,56 @@ contract SequenceExecutor {
         bool supportsBundleContext = false;
         if (hasBundleContext) {
             // Use low-level call to avoid revert if action doesn't implement ERC165
-            (bool success, bytes memory result) = actionAddress.staticcall(
+            (bool ercSuccess, bytes memory ercResult) = actionAddress.staticcall(
                 abi.encodeWithSelector(IERC165.supportsInterface.selector, type(IActionWithBundleContext).interfaceId)
             );
-            if (success && result.length >= 32) {
-                supportsBundleContext = abi.decode(result, (bool));
+            if (ercSuccess && ercResult.length >= 32) {
+                supportsBundleContext = abi.decode(ercResult, (bool));
             }
         }
-        
+
+        bool success;
+        bytes memory returnData;
         if (hasBundleContext && supportsBundleContext) {
-            _executeActionWithBundleContext(actionAddress, callData, _bundle, _signature, _strategyId);
+            (success, returnData) = _executeActionWithBundleContext(actionAddress, callData, _bundle, _signature, _strategyId);
         } else {
-            _executeActionStandard(actionAddress, callData);
+            (success, returnData) = _executeActionStandard(actionAddress, callData);
+        }
+
+        // Wrap any action failure in a SequenceExecutor-owned error, carrying the action's index
+        // and id with the original revert nested as `reason`. This pins the top-level selector to
+        // this contract so off-chain monitors can attribute the failure to a specific action and
+        // cannot be tricked by an action emitting bytes that mimic a native module-error selector.
+        if (!success) {
+            revert Errors.SequenceExecutor_ActionReverted(_index, actionId, returnData);
         }
     }
 
     // =============================
     // Standard (non-bundle) execution
     // =============================
-    function _executeActionStandard(address _actionAddress, bytes memory _fullCallData) internal {
-        if (_actionAddress == address(0)) {
-            assembly { revert(0, 0) }
-        }
-        // Delegatecall with provided calldata (non-bundle path)
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            let succeeded := delegatecall(sub(gas(), 5000), _actionAddress, add(_fullCallData, 0x20), mload(_fullCallData), 0, 0)
-            if eq(succeeded, 0) {
-                returndatacopy(0, 0, returndatasize())
-                revert(0, returndatasize())
-            }
-        }
+    /// @dev Delegatecalls the action with the provided calldata. Returns the raw outcome so the
+    ///      caller can wrap any failure with action context (see `_executeAction`).
+    function _executeActionStandard(address _actionAddress, bytes memory _fullCallData)
+        internal
+        returns (bool success, bytes memory returnData)
+    {
+        (success, returnData) = _actionAddress.delegatecall(_fullCallData);
     }
 
     // =============================
     // Bundle-context execution
     // =============================
+    /// @dev Delegatecalls the action through the bundle-context entry point. Returns the raw outcome
+    ///      so the caller can wrap any failure with action context (see `_executeAction`).
     function _executeActionWithBundleContext(
         address _actionAddress,
         bytes memory _actionCallData,
         IEip712TypedDataSafeModule.Bundle calldata _bundle,
         bytes calldata _signature,
         uint16 _strategyId
-    ) internal {
-        (bool success, bytes memory returnData) = _actionAddress.delegatecall(
+    ) internal returns (bool success, bytes memory returnData) {
+        (success, returnData) = _actionAddress.delegatecall(
             abi.encodeWithSelector(
                 IActionWithBundleContext.executeActionWithBundleContext.selector,
                 _actionCallData,
@@ -126,12 +132,5 @@ contract SequenceExecutor {
                 _strategyId
             )
         );
-        if (!success) {
-            if (returnData.length > 0) {
-                assembly { revert(add(returnData, 0x20), mload(returnData)) }
-            } else {
-                revert("Bundle action execution failed");
-            }
-        }
     }
 }

--- a/contracts/SequenceExecutorDebug.sol
+++ b/contracts/SequenceExecutorDebug.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.28;
+
+import {SequenceExecutor} from "./SequenceExecutor.sol";
+import {IEip712TypedDataSafeModule} from "./interfaces/IEip712TypedDataSafeModule.sol";
+import {IActionWithBundleContext} from "./interfaces/IActionWithBundleContext.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IAction} from "./interfaces/IAction.sol";
+import {Errors} from "./Errors.sol";
+import "hardhat/console.sol";
+
+// @dev Basically the same as SequenceExecutor, but with debug prints
+// @dev This is to be used for debugging only
+contract SequenceExecutorDebug is SequenceExecutor {
+    constructor(address _adminVault) SequenceExecutor(_adminVault) {}
+
+    function executeSequence(
+        Sequence calldata _currSequence,
+        IEip712TypedDataSafeModule.Bundle calldata _bundle,
+        bytes calldata _signature,
+        uint16 _strategyId
+    ) public payable virtual override {
+        console.log("Executing sequence:", _currSequence.name);
+        console.log("Number of actions:", _currSequence.actionIds.length);
+        console.log("Bundle sequences length:", _bundle.sequences.length);
+        console.log("Strategy ID:", _strategyId);
+
+        // Add check that the sequence is valid
+        for (uint256 i = 0; i < _currSequence.actionIds.length; ++i) {
+            try ADMIN_VAULT.getActionAddress(_currSequence.actionIds[i]) returns (address actionAddr) {
+                console.log("Action address from vault:", actionAddr);
+            } catch {
+                console.log("Action not found for ID:", uint256(uint32(_currSequence.actionIds[i])));
+            }
+        }
+
+        super.executeSequence(_currSequence, _bundle, _signature, _strategyId);
+    }
+
+    function _executeAction(
+        Sequence memory _currSequence,
+        uint256 _index,
+        IEip712TypedDataSafeModule.Bundle calldata _bundle,
+        bytes calldata _signature,
+        uint16 _strategyId
+    ) internal virtual override {
+        bytes4 actionId = _currSequence.actionIds[_index];
+        bytes memory callData = _currSequence.callData[_index];
+        address actionAddress = ADMIN_VAULT.getActionAddress(actionId);
+        
+        console.log("Executing action:", uint256(uint32(actionId)));
+        console.log("Action address:", actionAddress);
+        console.log("Call data length:", callData.length);
+        
+        if (actionAddress == address(0)) { 
+            console.log("Action not found for ID:", uint256(uint32(actionId)));
+            revert Errors.EIP712TypedDataSafeModule_ActionNotFound(actionId); 
+        }
+        
+        bool hasBundleContext = _bundle.sequences.length > 0;
+        console.log("Has bundle context:", hasBundleContext);
+        
+        if (hasBundleContext && IERC165(actionAddress).supportsInterface(type(IActionWithBundleContext).interfaceId)) {
+            console.log("Using bundle context for action");
+            // Bundle execution: Use delegate call to ensure address(this) = Safe
+            (bool success, bytes memory returnData) = actionAddress.delegatecall(
+                abi.encodeWithSelector(
+                    IActionWithBundleContext.executeActionWithBundleContext.selector,
+                    callData,
+                    _bundle,
+                    _signature,
+                    _strategyId
+                )
+            );
+            if (!success) {
+                console.log("Bundle action execution failed");
+                // Forward the revert reason for bundle actions
+                if (returnData.length > 0) {
+                    assembly {
+                        revert(add(returnData, 0x20), mload(returnData))
+                    }
+                } else {
+                    revert("Bundle action execution failed");
+                }
+            }
+        } else {
+            console.log("Using standard action execution");
+            // Delegate call to executeAction  
+            // Extract parameters from the encoded function call
+            // callData format: [4-byte selector][inputParams][strategyId]
+            
+            bytes memory actionCallData;
+            uint16 actionStrategyId;
+            
+            // Decode the function call to extract parameters
+            if (callData.length >= 4) {
+                bytes4 selector;
+                assembly {
+                    selector := mload(add(callData, 0x20))
+                }
+                if (selector == IAction.executeAction.selector) {
+                    // Create new bytes array for the parameters (skip first 4 bytes)
+                    bytes memory parametersData = new bytes(callData.length - 4);
+                    for (uint256 i = 0; i < callData.length - 4; i++) {
+                        parametersData[i] = callData[i + 4];
+                    }
+                    // Decode the parameters from the function call
+                    (actionCallData, actionStrategyId) = abi.decode(parametersData, (bytes, uint16));
+                } else {
+                    // Fallback: treat callData as raw parameters
+                    actionCallData = callData;
+                    actionStrategyId = _strategyId;
+                }
+            } else {
+                // Fallback: treat callData as raw parameters  
+                actionCallData = callData;
+                actionStrategyId = _strategyId;
+            }
+            
+            bytes memory delegateCallData = abi.encodeWithSelector(IAction.executeAction.selector, actionCallData, actionStrategyId);
+            
+            (bool success, bytes memory returnData) = actionAddress.delegatecall(delegateCallData);
+            if (!success) {
+                console.log("Action execution failed");
+                // Forward the revert reason
+                if (returnData.length > 0) {
+                    assembly {
+                        revert(add(returnData, 0x20), mload(returnData))
+                    }
+                } else {
+                    revert("Action execution failed");
+                }
+            }
+        }
+        
+        console.log("Action completed successfully");
+    }
+}

--- a/contracts/actions/ActionBase.sol
+++ b/contracts/actions/ActionBase.sol
@@ -73,10 +73,14 @@ abstract contract ActionBase is IActionBase {
         IERC20 vault = IERC20(_feeToken);
         uint256 balance = vault.balanceOf(address(this));
         uint256 fee = _calculateFee(balance, _feePercentage, lastFeeTimestamp, currentTimestamp);
+
+        // Record the fee timestamp before the external transfer (checks-effects-interactions) so a
+        // callback-capable fee token cannot re-enter on a stale timestamp and collect the period twice.
+        ADMIN_VAULT.setFeeTimestamp(_pool);
+
         if (fee > 0) {
             vault.safeTransfer(ADMIN_VAULT.feeConfig().recipient, fee);
         }
-        ADMIN_VAULT.setFeeTimestamp(_pool);
         return fee;
     }
 

--- a/contracts/actions/across-v3/AcrossV3Supply.sol
+++ b/contracts/actions/across-v3/AcrossV3Supply.sol
@@ -62,6 +62,10 @@ contract AcrossV3Supply is ActionBase {
 
         feeInTokens = _processFee(l1Token, _inputData.feeBasis, lpToken);
 
+        // Record the post-fee balance so a fee-only call (amount == 0) reports the real LP position
+        // rather than a zeroed-out one
+        sharesAfter = IERC20(lpToken).balanceOf(address(this));
+
         // If we have an amount to deposit, do that
         if (_inputData.amount != 0) {
             uint256 amountToDeposit = _inputData.amount == type(uint256).max

--- a/contracts/actions/across-v3/AcrossV3Supply.sol
+++ b/contracts/actions/across-v3/AcrossV3Supply.sol
@@ -60,7 +60,9 @@ contract AcrossV3Supply is ActionBase {
         // Get initial balance
         sharesBefore = IERC20(lpToken).balanceOf(address(this));
 
-        feeInTokens = _processFee(l1Token, _inputData.feeBasis, lpToken);
+        // Key the fee timestamp on the LP token (the held position). That is the token a later
+        // SendToken/swap passes to _checkFeesTaken, so both sides must agree on the same key.
+        feeInTokens = _processFee(lpToken, _inputData.feeBasis, lpToken);
 
         // Record the post-fee balance so a fee-only call (amount == 0) reports the real LP position
         // rather than a zeroed-out one

--- a/contracts/actions/across-v3/AcrossV3Withdraw.sol
+++ b/contracts/actions/across-v3/AcrossV3Withdraw.sol
@@ -60,7 +60,9 @@ contract AcrossV3Withdraw is ActionBase {
         // Get initial balance
         sharesBefore = IERC20(lpToken).balanceOf(address(this));
 
-        feeInTokens = _processFee(l1Token, _inputData.feeBasis, lpToken);
+        // Key the fee timestamp on the LP token (the held position) so supply and withdraw share the
+        // same key, matching the token a later SendToken/swap passes to _checkFeesTaken.
+        feeInTokens = _processFee(lpToken, _inputData.feeBasis, lpToken);
 
         uint256 underlyingBalance = _sharesToUnderlying(sharesBefore - feeInTokens, l1Token);
         /// @dev If the withdraw amount is greater or equal than the underlying balance, we withdraw the entire balance

--- a/contracts/actions/cctp/CCTPBridgeSend.sol
+++ b/contracts/actions/cctp/CCTPBridgeSend.sol
@@ -6,18 +6,10 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ActionBase} from "../ActionBase.sol";
 import {Errors} from "../../Errors.sol";
 import {ITokenMessengerV2} from "../../interfaces/ICCTP.sol";
-import {IAuthRegistry} from "../../interfaces/IAuthRegistry.sol";
 
 /// @title CCTPBridgeSend - Cross-chain USDC bridging via CCTP V2
-/// @notice Bridges USDC via CCTP V2, optionally propagating the source-chain auth config snapshot
-///         to the destination chain's `AuthRegistry` in the same attested message.
-/// @dev Two modes selected by `CCTPParams.propagateAuth`:
-///        - `false`: hookless `depositForBurn`; orchestrator picks any `destinationCaller`
-///                   (typically `CCTPBundleReceiver` for non-auth flows).
-///        - `true`:  reads the full auth config (managers, co-signers, thresholds) from the local
-///                   `AUTH_REGISTRY` for `address(this)` (the Safe under delegatecall), encodes
-///                   them into the CCTP V2 `hookData`, and forces
-///                   `destinationCaller = address(AUTH_REGISTRY)`.
+/// @notice Bridges USDC via CCTP V2 using a hookless `depositForBurn`; the orchestrator picks the
+///         `destinationCaller` (typically `CCTPBundleReceiver`).
 /// @dev The action executes via delegatecall from the Safe, so address(this) is the Safe during execution.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract CCTPBridgeSend is ActionBase {
@@ -28,12 +20,6 @@ contract CCTPBridgeSend is ActionBase {
     uint256 public constant DEFAULT_FAST_MAX_FEE = 1000000;
     uint256 public constant DEFAULT_STANDARD_MAX_FEE = 0;
 
-    /// @notice Hook envelope version for auth config snapshots embedded in CCTP V2 messages.
-    uint8 internal constant AUTH_HOOK_VERSION = 1;
-
-    /// @param propagateAuth When true, reads the Safe's auth config from `AUTH_REGISTRY` and
-    ///        embeds it into the CCTP V2 hookData; receiving registry triple-checks Safe identity
-    ///        and applies the snapshot in the same attested message.
     struct CCTPParams {
         address usdcToken;
         uint256 amount;
@@ -41,13 +27,9 @@ contract CCTPBridgeSend is ActionBase {
         bytes32 destinationCaller;
         uint256 maxFee;
         uint32 minFinalityThreshold;
-        bool propagateAuth;
     }
 
     ITokenMessengerV2 public immutable TOKEN_MESSENGER;
-
-    /// @notice Per-chain canonical store of auth state (managers, co-signers, thresholds).
-    IAuthRegistry public immutable AUTH_REGISTRY;
 
     /// @inheritdoc ActionBase
     function actionType() public pure override returns (uint8) {
@@ -62,14 +44,12 @@ contract CCTPBridgeSend is ActionBase {
     constructor(
         address _adminVault,
         address _logger,
-        address _tokenMessenger,
-        address _authRegistry
+        address _tokenMessenger
     ) ActionBase(_adminVault, _logger) {
-        if (_tokenMessenger == address(0) || _authRegistry == address(0)) {
+        if (_tokenMessenger == address(0)) {
             revert Errors.InvalidInput("CCTPBridgeSend", "constructor");
         }
         TOKEN_MESSENGER = ITokenMessengerV2(_tokenMessenger);
-        AUTH_REGISTRY = IAuthRegistry(_authRegistry);
     }
 
     /// @inheritdoc ActionBase
@@ -81,15 +61,23 @@ contract CCTPBridgeSend is ActionBase {
             params.destinationDomain,
             params.destinationCaller,
             params.maxFee,
-            params.minFinalityThreshold,
-            params.propagateAuth
-        ) = abi.decode(_callData, (address, uint256, uint32, bytes32, uint256, uint32, bool));
+            params.minFinalityThreshold
+        ) = abi.decode(_callData, (address, uint256, uint32, bytes32, uint256, uint32));
 
         if (
             params.usdcToken == address(0) ||
             params.amount == 0 ||
-            (!params.propagateAuth && params.destinationCaller == bytes32(0))
+            params.destinationCaller == bytes32(0)
         ) revert Errors.InvalidInput("CCTPBridgeSend", "executeAction");
+
+        // Pin the bridged asset to the chain's USDC, configured per-chain in AdminVault. CCTP V2's
+        // TokenMessenger can burn other registered tokens (e.g. EURC), so matching against an
+        // admin-set address stops an authorised manager from bridging the wrong asset. The bytecode
+        // stays chain-agnostic: a new chain is enabled with a single setActionConfig, no redeploy.
+        address expectedUsdc = _configAddress();
+        if (params.usdcToken != expectedUsdc) {
+            revert Errors.CCTPBridgeSend_UnexpectedToken(params.usdcToken, expectedUsdc);
+        }
 
         _executeCCTPBridge(params, _strategyId);
     }
@@ -106,43 +94,6 @@ contract CCTPBridgeSend is ActionBase {
 
         bytes32 mintRecipient = bytes32(uint256(uint160(address(this))));
 
-        if (params.propagateAuth) {
-            _bridgeWithAuth(params, mintRecipient);
-        } else {
-            _bridgeHookless(params, mintRecipient);
-        }
-
-        uint256 balanceAfter = IERC20(params.usdcToken).balanceOf(address(this));
-        if (balanceBefore - balanceAfter != params.amount) {
-            revert Errors.CCTPBridgeSend_BalanceMismatch(balanceBefore, balanceAfter, params.amount);
-        }
-
-        if (params.propagateAuth) {
-            uint256 version = AUTH_REGISTRY.getVersion(address(this));
-            LOGGER.logActionEvent(
-                LogType.CCTP_BRIDGE_SEND_WITH_AUTH,
-                abi.encode(
-                    address(this),
-                    params.amount,
-                    params.destinationDomain,
-                    bytes32(uint256(uint160(address(AUTH_REGISTRY)))),
-                    version
-                )
-            );
-        } else {
-            LOGGER.logActionEvent(
-                LogType.CCTP_BRIDGE_SEND,
-                abi.encode(
-                    address(this),
-                    params.amount,
-                    params.destinationDomain,
-                    params.destinationCaller
-                )
-            );
-        }
-    }
-
-    function _bridgeHookless(CCTPParams memory params, bytes32 mintRecipient) private {
         TOKEN_MESSENGER.depositForBurn(
             params.amount,
             params.destinationDomain,
@@ -152,60 +103,29 @@ contract CCTPBridgeSend is ActionBase {
             params.maxFee,
             params.minFinalityThreshold
         );
-    }
 
-    /// @dev Auth-propagating path. Reads the full auth config for `address(this)` (the Safe
-    ///      under delegatecall), encodes it into a hookVersion-1 envelope, and forces
-    ///      `destinationCaller = address(AUTH_REGISTRY)`.
-    function _bridgeWithAuth(CCTPParams memory params, bytes32 mintRecipient) private {
-        bytes memory hookData = _buildAuthHookData();
-        bytes32 destinationCaller = bytes32(uint256(uint160(address(AUTH_REGISTRY))));
-
-        TOKEN_MESSENGER.depositForBurnWithHook(
-            params.amount,
-            params.destinationDomain,
-            mintRecipient,
-            params.usdcToken,
-            destinationCaller,
-            params.maxFee,
-            params.minFinalityThreshold,
-            hookData
-        );
-    }
-
-    /// @dev Reads the full auth config snapshot from `AUTH_REGISTRY` for this Safe
-    ///      and encodes it into a hook envelope for cross-chain propagation.
-    ///      This reads the registry AFTER any authUpdate in the same bundle has applied.
-    ///      That ordering is intentional and load-bearing — the destination chain
-    ///      receives the post-update state.
-    function _buildAuthHookData() private view returns (bytes memory) {
-        address safe = address(this);
-        address[] memory managers = AUTH_REGISTRY.getManagers(safe);
-
-        uint256[] memory bitmaps = new uint256[](managers.length);
-        for (uint256 i; i < managers.length; ++i) {
-            bitmaps[i] = AUTH_REGISTRY.getManagerActionBitmap(safe, managers[i]);
+        uint256 balanceAfter = IERC20(params.usdcToken).balanceOf(address(this));
+        if (balanceBefore - balanceAfter != params.amount) {
+            revert Errors.CCTPBridgeSend_BalanceMismatch(balanceBefore, balanceAfter, params.amount);
         }
 
-        bytes memory payload = abi.encode(
-            safe,
-            AUTH_REGISTRY.getVersion(safe),
-            managers,
-            AUTH_REGISTRY.getCoSigners(safe),
-            AUTH_REGISTRY.getManagerCoSignThreshold(safe),
-            bitmaps
+        LOGGER.logActionEvent(
+            LogType.CCTP_BRIDGE_SEND,
+            abi.encode(
+                address(this),
+                params.amount,
+                params.destinationDomain,
+                params.destinationCaller
+            )
         );
-        return abi.encode(AUTH_HOOK_VERSION, payload);
     }
-
 
     function createFastTransferParams(
         address usdcToken,
         uint256 amount,
         uint32 destinationDomain,
         address destinationCaller,
-        uint256 customMaxFee,
-        bool propagateAuth
+        uint256 customMaxFee
     ) external pure returns (CCTPParams memory) {
         return CCTPParams({
             usdcToken: usdcToken,
@@ -213,8 +133,7 @@ contract CCTPBridgeSend is ActionBase {
             destinationDomain: destinationDomain,
             destinationCaller: bytes32(uint256(uint160(destinationCaller))),
             maxFee: customMaxFee > 0 ? customMaxFee : DEFAULT_FAST_MAX_FEE,
-            minFinalityThreshold: FAST_FINALITY_THRESHOLD,
-            propagateAuth: propagateAuth
+            minFinalityThreshold: FAST_FINALITY_THRESHOLD
         });
     }
 
@@ -222,8 +141,7 @@ contract CCTPBridgeSend is ActionBase {
         address usdcToken,
         uint256 amount,
         uint32 destinationDomain,
-        address destinationCaller,
-        bool propagateAuth
+        address destinationCaller
     ) external pure returns (CCTPParams memory) {
         return CCTPParams({
             usdcToken: usdcToken,
@@ -231,8 +149,7 @@ contract CCTPBridgeSend is ActionBase {
             destinationDomain: destinationDomain,
             destinationCaller: bytes32(uint256(uint160(destinationCaller))),
             maxFee: DEFAULT_STANDARD_MAX_FEE,
-            minFinalityThreshold: STANDARD_FINALITY_THRESHOLD,
-            propagateAuth: propagateAuth
+            minFinalityThreshold: STANDARD_FINALITY_THRESHOLD
         });
     }
 }

--- a/contracts/actions/cctp/CCTPBundleReceiver.sol
+++ b/contracts/actions/cctp/CCTPBundleReceiver.sol
@@ -22,15 +22,20 @@ import {ISafe} from "../../interfaces/safe/ISafe.sol";
  *
  *      The destination Brava module is discovered at relay time via ERC-165 introspection
  *      on the Safe's enabled modules (`BravaModuleLookup`). The receiver therefore holds no
- *      module address and survives Brava module upgrades unchanged. Auth-carrying CCTP
- *      messages route through `AuthRegistry.relayCCTPAndExecute` instead of this contract.
+ *      module address and survives Brava module upgrades unchanged. CCTP messages carry no auth
+ *      data — they only mint USDC and best-effort execute a separately-signed bundle.
  *
- *      Permissionless by intent: any executor may call relay/relayWithBundle.
+ *      Permissionless by intent. relayWithBundle's mint is idempotent, so a prior relay cannot
+ *      block it from executing the bundle. relay() is a plain mint that reverts if already consumed.
  */
 contract CCTPBundleReceiver {
 
     /// @notice MessageTransmitter contract - configurable for testing
     address public immutable MESSAGE_TRANSMITTER;
+
+    /// @notice Circle TokenMessenger V2 on this chain. A genuine burn message names this contract
+    ///         in both the outer header `sender` and `recipient` fields; generic Circle messages do not.
+    address public immutable TOKEN_MESSENGER;
 
     /// @notice Logger contract for emitting ActionEvent logs consumed by the indexer
     ILogger public immutable LOGGER;
@@ -38,9 +43,25 @@ contract CCTPBundleReceiver {
     /// @notice Byte offset within a CCTP V2 message where the source domain field begins (uint32).
     uint256 private constant SOURCE_DOMAIN_OFFSET = 4;
 
+    /// @notice CCTP V2 message header size in bytes; the burn body (and its version) begins here.
+    uint256 private constant MESSAGE_HEADER_SIZE = 148;
+
+    /// @notice Byte offset of the outer header `sender` (source-chain TokenMessenger), as bytes32.
+    uint256 private constant HEADER_SENDER_OFFSET = 44;
+
+    /// @notice Byte offset of the outer header `recipient` (destination-chain TokenMessenger), as bytes32.
+    uint256 private constant HEADER_RECIPIENT_OFFSET = 76;
+
+    /// @notice CCTP V2 version expected in both the outer header and the burn body.
+    uint32 private constant CCTP_V2_VERSION = 1;
+
     /// @notice Byte offset within a CCTP V2 message where the nonce field begins.
     ///         Layout: version (4) + sourceDomain (4) + destinationDomain (4) = 12 bytes.
     uint256 private constant NONCE_OFFSET = 12;
+
+    /// @notice Byte offset within a CCTP V2 message where the BurnMessage mintRecipient field begins.
+    ///         Layout: 148-byte message header + 4-byte burn version + 32-byte burnToken.
+    uint256 private constant MINT_RECIPIENT_OFFSET = 184;
 
     /// @notice Byte offset within a CCTP V2 message where the BurnMessage amount field begins.
     ///         Layout: 148-byte message header + 68-byte BurnMessage prefix (version + burnToken + mintRecipient).
@@ -57,6 +78,9 @@ contract CCTPBundleReceiver {
         cctpNonce = bytes32(message[NONCE_OFFSET:NONCE_OFFSET + 32]);
     }
 
+    /// @dev Emits the indexer event recording the destination mint leg. Fired on every successful
+    ///      mint (mint-only relay and relayWithBundle alike); `bundleSuccess` carries the bundle's
+    ///      best-effort outcome, or true when no bundle ran.
     function _logBundleReceive(
         address safeAddress,
         bool bundleSuccess,
@@ -70,38 +94,34 @@ contract CCTPBundleReceiver {
     }
 
     /**
-     * @notice Constructor sets the MessageTransmitter and Logger addresses
+     * @notice Constructor sets the MessageTransmitter, TokenMessenger, and Logger addresses
      * @param _messageTransmitter Address of the MessageTransmitter contract (Circle's or mock for testing)
+     * @param _tokenMessenger Circle TokenMessenger V2 on this chain; burn messages must name it as sender and recipient
      * @param _logger Address of the Logger contract for indexer event emission
      */
-    constructor(address _messageTransmitter, address _logger) {
-        if (_messageTransmitter == address(0) || _logger == address(0)) {
+    constructor(address _messageTransmitter, address _tokenMessenger, address _logger) {
+        if (_messageTransmitter == address(0) || _tokenMessenger == address(0) || _logger == address(0)) {
             revert Errors.InvalidInput("CCTPBundleReceiver", "constructor");
         }
         MESSAGE_TRANSMITTER = _messageTransmitter;
+        TOKEN_MESSENGER = _tokenMessenger;
         LOGGER = ILogger(_logger);
     }
 
     /**
-     * @notice Relay a CCTP message and execute a bundle in a single transaction
-     * @dev Called by tx-orchestrator with bundle data from offchain storage
-     *
-     *      Flow:
-     *      1. Relay CCTP message via Circle's MessageTransmitter (mints USDC to Safe)
-     *      2. Discover the Safe's enabled Brava module via ERC-165 (`BravaModuleLookup`)
-     *      3. Execute bundle on the discovered module (best-effort, non-reverting)
-     *
-     *      The bundle comes from tx-orchestrator (signed by user), not from CCTP message.
-     *      This bypasses CCTP's hook data size limit.
-     *
+     * @notice Relay a CCTP message and optionally execute a bundle in a single transaction.
+     * @dev Mints USDC to the Safe (idempotent — see `_mintIfNeeded`), then, if `bundle.sequences`
+     *      is non-empty, discovers the Safe's enabled Brava module via ERC-165 and executes the
+     *      bundle best-effort. Empty sequences = mint-only relay. The bundle is supplied by the
+     *      tx-orchestrator (user-signed), bypassing CCTP's hook data size limit.
      * @param message Full CCTP V2 message bytes from Circle attestation
      * @param attestation Circle attestation bytes
-     * @param safeAddress The Safe address to execute the bundle on
-     * @param bundle The bundle containing sequences for execution
+     * @param safeAddress The Safe address to execute the bundle on; must equal the attested mintRecipient
+     * @param bundle Bundle sequences to execute (empty = mint-only)
      * @param signature EIP-712 signature from a Safe owner
-     * @return relaySuccess True if receiveMessage succeeded (USDC minted)
+     * @return relaySuccess True once USDC is present at the Safe (reverts if a fresh mint fails)
      * @return bundleSuccess True if bundle execution succeeded
-     * @return bundleReturnData Return data from bundle execution (useful for debugging)
+     * @return bundleReturnData Revert data from a failed bundle execution (empty otherwise)
      */
     function relayWithBundle(
         bytes calldata message,
@@ -115,13 +135,36 @@ contract CCTPBundleReceiver {
         bytes memory bundleReturnData
     ) {
         _validateMessageFormat(message);
+        _assertSafeMatchesMintRecipient(message, safeAddress);
 
-        relaySuccess = IMessageTransmitterV2(MESSAGE_TRANSMITTER).receiveMessage(message, attestation);
-        if (!relaySuccess) revert Errors.CCTPReceiver_RelayFailed();
+        relaySuccess = _mintIfNeeded(message, attestation);
 
-        (bundleSuccess, bundleReturnData) = _executeBundleBestEffort(safeAddress, bundle, signature);
+        // Always emit the destination leg once USDC is minted so the indexer can link the bridge
+        // regardless of whether a bundle ran. A mint-only relay reports success (no bundle to fail);
+        // a relay with a bundle reports the bundle's real best-effort outcome.
+        bool ranBundle = bundle.sequences.length > 0;
+        if (ranBundle) {
+            (bundleSuccess, bundleReturnData) = _executeBundleBestEffort(safeAddress, bundle, signature);
+        }
+        _logBundleReceive(safeAddress, ranBundle ? bundleSuccess : true, message);
+    }
 
-        _logBundleReceive(safeAddress, bundleSuccess, message);
+    /// @dev Idempotent mint: skips `receiveMessage` when the nonce is already consumed (funds already
+    ///      at the Safe), so a third party relaying first cannot block bundle execution. A fresh mint
+    ///      that fails reverts the whole call.
+    /// @return relaySuccess True once USDC is present at the Safe.
+    function _mintIfNeeded(
+        bytes calldata message,
+        bytes calldata attestation
+    ) private returns (bool relaySuccess) {
+        bytes32 nonce = bytes32(message[NONCE_OFFSET:NONCE_OFFSET + 32]);
+        if (IMessageTransmitterV2(MESSAGE_TRANSMITTER).usedNonces(nonce) != 0) {
+            return true;
+        }
+        if (!IMessageTransmitterV2(MESSAGE_TRANSMITTER).receiveMessage(message, attestation)) {
+            revert Errors.CCTPReceiver_RelayFailed();
+        }
+        relaySuccess = true;
     }
 
     /// @dev Discovers the Safe's currently-enabled Brava module via ERC-165 and forwards the
@@ -143,20 +186,53 @@ contract CCTPBundleReceiver {
         }
     }
 
-    /// @dev Reverts if the message is too short or the CCTP V2 version field is not 1.
-    function _validateMessageFormat(bytes calldata message) private pure {
+    /// @dev The attested mint recipient (the Safe Circle credits the USDC to), read from the burn body.
+    function _mintRecipient(bytes calldata message) private pure returns (address) {
+        return address(uint160(uint256(bytes32(message[MINT_RECIPIENT_OFFSET:MINT_RECIPIENT_OFFSET + 32]))));
+    }
+
+    /// @dev Binds bundle execution to the attested mint recipient: the Safe the bundle runs on must
+    ///      be the Safe Circle credits the USDC to, so a relayer cannot pair a mint with an unrelated
+    ///      Safe's bundle. The mint destination itself is fixed by the attested message regardless.
+    function _assertSafeMatchesMintRecipient(bytes calldata message, address safeAddress) private pure {
+        if (_mintRecipient(message) != safeAddress) {
+            revert Errors.CCTPReceiver_SafeMintRecipientMismatch(
+                safeAddress,
+                bytes32(message[MINT_RECIPIENT_OFFSET:MINT_RECIPIENT_OFFSET + 32])
+            );
+        }
+    }
+
+    /// @dev Confirms the message is a genuine CCTP V2 TokenMessenger burn message before any mint is
+    ///      credited or bundle is run. Beyond the size and outer-version checks, it requires the burn
+    ///      body version and the header `sender`/`recipient` to name `TOKEN_MESSENGER`, so a generic
+    ///      Circle message with burn-shaped bytes cannot be relayed as a USDC bridge.
+    function _validateMessageFormat(bytes calldata message) private view {
         if (message.length < MIN_MESSAGE_SIZE) revert Errors.CCTPReceiver_BadMessage();
 
         uint32 version = uint32(bytes4(message[0:4]));
-        if (version != 1) revert Errors.CCTPReceiver_BadVersion(version);
+        if (version != CCTP_V2_VERSION) revert Errors.CCTPReceiver_BadVersion(version);
+
+        uint32 burnVersion = uint32(bytes4(message[MESSAGE_HEADER_SIZE:MESSAGE_HEADER_SIZE + 4]));
+        if (burnVersion != CCTP_V2_VERSION) revert Errors.CCTPReceiver_BadBurnVersion(burnVersion);
+
+        bytes32 trustedMessenger = bytes32(uint256(uint160(TOKEN_MESSENGER)));
+
+        bytes32 headerSender = bytes32(message[HEADER_SENDER_OFFSET:HEADER_SENDER_OFFSET + 32]);
+        if (headerSender != trustedMessenger) revert Errors.CCTPReceiver_UntrustedSender(headerSender);
+
+        bytes32 headerRecipient = bytes32(message[HEADER_RECIPIENT_OFFSET:HEADER_RECIPIENT_OFFSET + 32]);
+        if (headerRecipient != trustedMessenger) revert Errors.CCTPReceiver_UntrustedRecipient(headerRecipient);
     }
 
     /**
-     * @notice Simple relay without bundle execution (for USDC-only transfers or manual bundle execution)
-     * @dev Useful when bundle should be executed separately or when no bundle is needed
+     * @notice Mint-only relay: delivers USDC to the Safe with no bundle execution.
+     * @dev For callers that only need the mint (e.g. manual/ops relays). Always performs the relay
+     *      and reverts if the message can't be relayed (including an already-consumed nonce); unlike
+     *      `relayWithBundle`, the mint here is not idempotent.
      * @param message Full CCTP V2 message bytes
      * @param attestation Circle attestation bytes
-     * @return relaySuccess True if receiveMessage succeeded
+     * @return relaySuccess True when this call performed the relay (reverts otherwise)
      */
     function relay(
         bytes calldata message,
@@ -165,5 +241,8 @@ contract CCTPBundleReceiver {
         _validateMessageFormat(message);
         relaySuccess = IMessageTransmitterV2(MESSAGE_TRANSMITTER).receiveMessage(message, attestation);
         if (!relaySuccess) revert Errors.CCTPReceiver_RelayFailed();
+        // Emit the destination leg so a mint-only relay is observable to the indexer just like a
+        // relayWithBundle. No bundle ran here, so the receive is reported as successful.
+        _logBundleReceive(_mintRecipient(message), true, message);
     }
 }

--- a/contracts/actions/cctp/MockMessageTransmitter.sol
+++ b/contracts/actions/cctp/MockMessageTransmitter.sol
@@ -22,21 +22,31 @@ contract MockMessageTransmitter {
 	
 	mapping(uint64 => StoredMessage) public storedMessages;
 	uint64 public latestStoredNonce;
+
+	/// @notice Mirrors Circle's replay-protection map (0 = unused, 1 = used), keyed by the bytes32
+	///         message nonce. Lets tests reproduce nonce-already-consumed relays.
+	mapping(bytes32 => uint256) public usedNonces;
 	
 	constructor(address _usdc) {
 		USDC = _usdc;
 	}
 	
-	/// @notice Simulates CCTP receiveMessage
-	/// @dev Mints stored amount to recipient and returns true on success
+	/// @notice Simulates CCTP receiveMessage with replay protection and destinationCaller enforcement
+	/// @dev Mints stored amount to recipient and returns true on success. Reverts on a reused nonce
+	///      or a caller that does not match a non-zero destinationCaller, matching Circle's behaviour.
     function receiveMessage(bytes calldata message, bytes calldata /* attestation */) external returns (bool) {
 		bytes32 nonceBytes;
 		assembly {
 			nonceBytes := calldataload(add(message.offset, 12))
 		}
+		require(usedNonces[nonceBytes] == 0, "Nonce already used");
 		uint64 nonce = uint64(uint256(nonceBytes));
 		StoredMessage memory m = storedMessages[nonce];
 		require(m.exists, "MockMessageTransmitter: No message");
+		if (m.destinationCaller != address(0)) {
+			require(msg.sender == m.destinationCaller, "Invalid caller");
+		}
+		usedNonces[nonceBytes] = 1;
 		IERC20(USDC).transfer(m.mintRecipient, m.amount);
 		return true;
 	}
@@ -96,25 +106,36 @@ contract MockMessageTransmitter {
 	
 	/// @notice Helper: build a minimal CCTP V2 message with correct structure for CCTPBundleReceiver
 	/// @dev CCTPBundleReceiver expects: 148-byte header + 228-byte BurnMessageV2 + hookData (total 376 bytes before hook)
-	///      Amount is placed at offset 68 within BurnMessage (= offset 216 in the full message).
+	///      Amount is placed at offset 68 within BurnMessage (= offset 216 in the full message). The header
+	///      sender (offset 44) and recipient (offset 76) carry this mock's address, standing in for the
+	///      TokenMessenger the receiver validates against.
 	function buildMessageWithHook(uint64 nonce) external view returns (bytes memory message) {
 		StoredMessage memory m = storedMessages[nonce];
 		require(m.exists, "MockMessageTransmitter: No message");
-		// CCTP V2 Message Header (148 bytes)
-		bytes memory header = abi.encodePacked(
+		// CCTP V2 Message Header (148 bytes): version, sourceDomain, destinationDomain, nonce,
+		// then sender (offset 44) and recipient (offset 76) both set to this mock (the TokenMessenger stand-in).
+		bytes memory paddedHeader = new bytes(148);
+		bytes memory headerPrefix = abi.encodePacked(
 			uint32(1),                    // version (4 bytes)
 			uint32(m.sourceDomain),       // sourceDomain (4 bytes)
 			uint32(m.destinationDomain),  // destinationDomain (4 bytes)
 			bytes32(uint256(nonce))       // nonce (32 bytes)
 		); // = 44 bytes
-		// Pad to 148 bytes (header size)
-		bytes memory paddedHeader = new bytes(148);
-		for (uint i = 0; i < 44 && i < 148; i++) {
-			paddedHeader[i] = header[i];
+		for (uint i = 0; i < 44; i++) {
+			paddedHeader[i] = headerPrefix[i];
 		}
-		// BurnMessageV2 fixed fields (228 bytes)
-		// Amount lives at offset 68 within BurnMessage (version(4) + burnToken(32) + mintRecipient(32) = 68)
+		bytes32 messenger = bytes32(uint256(uint160(address(this))));
+		for (uint i = 0; i < 32; i++) {
+			paddedHeader[44 + i] = messenger[i];
+			paddedHeader[76 + i] = messenger[i];
+		}
+		// BurnMessageV2 fixed fields (228 bytes): burn version at offset 0, amount at offset 68
+		// (version(4) + burnToken(32) + mintRecipient(32) = 68).
 		bytes memory burnMessage = new bytes(228);
+		bytes4 burnVersion = bytes4(uint32(1));
+		for (uint i = 0; i < 4; i++) {
+			burnMessage[i] = burnVersion[i];
+		}
 		bytes32 amountBytes = bytes32(m.amount);
 		for (uint i = 0; i < 32; i++) {
 			burnMessage[68 + i] = amountBytes[i];

--- a/contracts/actions/common/ERC4626Supply.sol
+++ b/contracts/actions/common/ERC4626Supply.sol
@@ -85,6 +85,10 @@ abstract contract ERC4626Supply is ActionBase {
                 ? maxDeposit 
                 : amountToDeposit;
 
+            // A vault reporting maxDeposit == 0 would otherwise deposit nothing and emit a misleading
+            // zero-amount supply; reject it the same way the withdraw path does
+            require(amountToDeposit != 0, Errors.Action_ZeroAmount(_vaultAddress, protocolName(), uint8(actionType())));
+
             // Perform the deposit
             _increaseAllowance(address(underlyingToken), _vaultAddress, amountToDeposit);
             uint256 shares = _deposit(_vaultAddress, amountToDeposit);

--- a/contracts/actions/maple-v1/MapleWithdrawQueue.sol
+++ b/contracts/actions/maple-v1/MapleWithdrawQueue.sol
@@ -29,16 +29,18 @@ contract MapleWithdrawQueue is ShareBasedWithdraw {
         uint256 /* _minUnderlyingReceived */
     ) internal override {
         IMaplePool pool = IMaplePool(_vaultAddress);
-        
-        // Get the withdrawal manager address from the pool
+
         address withdrawalManager = IMaplePoolManager(pool.manager()).withdrawalManager();
-        
-        // Get the next request ID which will be our request ID once submitted
-        (uint256 requestId, ) = IMapleWithdrawalManager(withdrawalManager).queue();
-        
-        // Submit a withdrawal request for the specified number of shares
+
+        // Submit the withdrawal request. Maple escrows the shares and appends the
+        // request to its FIFO queue; the underlying assets are released later when
+        // Maple's pool delegate processes the queue.
         pool.requestRedeem(_sharesToBurn, address(this));
-        
+
+        // The request just submitted is the newest entry in the queue, so the
+        // queue's lastRequestId identifies it.
+        (, uint256 requestId) = IMapleWithdrawalManager(withdrawalManager).queue();
+
         LOGGER.logActionEvent(
             LogType.WITHDRAWAL_REQUEST,
             abi.encode(_vaultAddress, _sharesToBurn, requestId)

--- a/contracts/actions/morpho-markets/MorphoMarketsSupply.sol
+++ b/contracts/actions/morpho-markets/MorphoMarketsSupply.sol
@@ -130,13 +130,15 @@ contract MorphoMarketsSupply is ActionBase {
         uint256 positionAssets = (pos.supplyShares * uint256(mkt.totalSupplyAssets)) / uint256(mkt.totalSupplyShares);
         uint256 fee = _calculateFee(positionAssets, _feeBasis, lastFeeTimestamp, currentTimestamp);
 
+        // Record the fee timestamp before withdrawing/transferring the fee (checks-effects-interactions)
+        // so a callback-capable loan token cannot re-enter on a stale timestamp and collect twice.
+        ADMIN_VAULT.setFeeTimestamp(feeKey);
+
         if (fee > 0) {
             (uint256 actualFee,) = _morpho.withdraw(_marketParams, fee, 0, address(this), address(this));
             IERC20(_marketParams.loanToken).safeTransfer(ADMIN_VAULT.feeConfig().recipient, actualFee);
             feeInTokens = actualFee;
         }
-
-        ADMIN_VAULT.setFeeTimestamp(feeKey);
     }
 
     function _parseInputs(bytes memory _callData) private pure returns (Params memory inputData) {

--- a/contracts/actions/morpho-markets/MorphoMarketsSupply.sol
+++ b/contracts/actions/morpho-markets/MorphoMarketsSupply.sol
@@ -11,24 +11,29 @@ import {ActionBase} from "../ActionBase.sol";
 /// @notice Morpho Blue markets are NOT ERC4626; this action interacts with the Morpho Blue
 ///         singleton contract directly using market-level supply/withdraw functions.
 /// @dev The Morpho Blue singleton address is read from AdminVault via _configAddress().
-///      Each whitelisted market's loan token is registered as a pool in AdminVault.
-///      The specific market is identified by a bytes32 marketId passed in calldata.
+///      Each market is whitelisted individually: marketKey = address(uint160(uint256(marketId)))
+///      is registered as a pool in AdminVault, so authorization binds the exact market
+///      (and therefore its full MarketParams), not just the shared loan token.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract MorphoMarketsSupply is ActionBase {
     using SafeERC20 for IERC20;
 
+    /// @notice Virtual shares/assets used by Morpho Blue's SharesMathLib for
+    ///         share<->asset conversion; mirroring them keeps our position
+    ///         valuation identical to what Morpho enforces on-chain.
+    uint256 private constant VIRTUAL_SHARES = 1e6;
+    uint256 private constant VIRTUAL_ASSETS = 1;
+
     /// @notice Parameters for the supply action
-    /// @param poolId Identifies the registered loan token in AdminVault
+    /// @param marketId The Morpho Blue market identifier (keccak256 of MarketParams); the whitelist unit
     /// @param feeBasis Fee percentage to apply (in basis points, e.g., 100 = 1%)
     /// @param amount Amount of underlying loan token to supply (type(uint256).max for full balance)
     /// @param minSharesReceived Minimum Morpho supply shares to receive (slippage protection)
-    /// @param marketId The Morpho Blue market identifier (keccak256 of MarketParams)
     struct Params {
-        bytes4 poolId;
+        bytes32 marketId;
         uint16 feeBasis;
         uint256 amount;
         uint256 minSharesReceived;
-        bytes32 marketId;
     }
 
     constructor(address _adminVault, address _logger) ActionBase(_adminVault, _logger) {}
@@ -38,19 +43,26 @@ contract MorphoMarketsSupply is ActionBase {
         Params memory inputData = _parseInputs(_callData);
         ADMIN_VAULT.checkFeeBasis(inputData.feeBasis);
 
-        address loanToken = ADMIN_VAULT.getPoolAddress(protocolName(), inputData.poolId);
+        // Authorize the exact market: marketKey is derived from the marketId and must be a
+        // whitelisted pool. This binds approval to the full MarketParams, not the shared loan token.
+        address marketKey = address(uint160(uint256(inputData.marketId)));
+        bytes4 poolId = _poolIdFromAddress(marketKey);
+        require(
+            ADMIN_VAULT.getPoolAddress(protocolName(), poolId) == marketKey,
+            Errors.InvalidInput(protocolName(), "marketId")
+        );
+
         IMorphoBlue morpho = IMorphoBlue(_configAddress());
         Id id = Id.wrap(inputData.marketId);
         MarketParams memory marketParams = morpho.idToMarketParams(id);
-        require(marketParams.loanToken == loanToken, Errors.InvalidInput(protocolName(), "marketId"));
 
         (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) = _supplyToMarket(
-            inputData, morpho, id, marketParams
+            inputData, morpho, id, marketParams, marketKey
         );
 
         LOGGER.logActionEvent(
             LogType.BALANCE_UPDATE,
-            _encodeBalanceUpdate(_strategyId, inputData.poolId, sharesBefore, sharesAfter, feeInTokens)
+            _encodeBalanceUpdate(_strategyId, poolId, sharesBefore, sharesAfter, feeInTokens)
         );
     }
 
@@ -58,11 +70,12 @@ contract MorphoMarketsSupply is ActionBase {
         Params memory _inputData,
         IMorphoBlue _morpho,
         Id _id,
-        MarketParams memory _marketParams
+        MarketParams memory _marketParams,
+        address _marketKey
     ) private returns (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) {
         sharesBefore = _morpho.position(_id, address(this)).supplyShares;
 
-        feeInTokens = _processMorphoFee(_morpho, _id, _marketParams, _inputData.feeBasis);
+        feeInTokens = _processMorphoFee(_morpho, _id, _marketParams, _marketKey, _inputData.feeBasis);
 
         if (_inputData.amount != 0) {
             IERC20 underlyingToken = IERC20(_marketParams.loanToken);
@@ -98,14 +111,16 @@ contract MorphoMarketsSupply is ActionBase {
 
     /// @notice Processes fees for a Morpho Blue position by withdrawing underlying from the market
     /// @dev Morpho Blue positions are not ERC20 tokens, so fees are taken in the underlying
-    ///      loan token by partially withdrawing from the supply position.
+    ///      loan token by partially withdrawing from the supply position. The fee timestamp is
+    ///      keyed per-market (marketKey), so markets sharing a loan token accrue independently.
     function _processMorphoFee(
         IMorphoBlue _morpho,
         Id _id,
         MarketParams memory _marketParams,
+        address _marketKey,
         uint256 _feeBasis
     ) private returns (uint256 feeInTokens) {
-        address feeKey = _marketParams.loanToken;
+        address feeKey = _marketKey;
         uint256 lastFeeTimestamp = ADMIN_VAULT.getLastFeeTimestamp(feeKey);
 
         if (lastFeeTimestamp == 0) {
@@ -127,7 +142,7 @@ contract MorphoMarketsSupply is ActionBase {
         _morpho.accrueInterest(_marketParams);
         Market memory mkt = _morpho.market(_id);
 
-        uint256 positionAssets = (pos.supplyShares * uint256(mkt.totalSupplyAssets)) / uint256(mkt.totalSupplyShares);
+        uint256 positionAssets = _toAssetsDown(pos.supplyShares, mkt);
         uint256 fee = _calculateFee(positionAssets, _feeBasis, lastFeeTimestamp, currentTimestamp);
 
         // Record the fee timestamp before withdrawing/transferring the fee (checks-effects-interactions)
@@ -139,6 +154,13 @@ contract MorphoMarketsSupply is ActionBase {
             IERC20(_marketParams.loanToken).safeTransfer(ADMIN_VAULT.feeConfig().recipient, actualFee);
             feeInTokens = actualFee;
         }
+    }
+
+    /// @notice Converts supply shares to assets, matching Morpho Blue's
+    ///         SharesMathLib.toAssetsDown semantics
+    function _toAssetsDown(uint256 _shares, Market memory _mkt) private pure returns (uint256) {
+        return (_shares * (uint256(_mkt.totalSupplyAssets) + VIRTUAL_ASSETS))
+            / (uint256(_mkt.totalSupplyShares) + VIRTUAL_SHARES);
     }
 
     function _parseInputs(bytes memory _callData) private pure returns (Params memory inputData) {

--- a/contracts/actions/morpho-markets/MorphoMarketsWithdraw.sol
+++ b/contracts/actions/morpho-markets/MorphoMarketsWithdraw.sol
@@ -11,24 +11,29 @@ import {ActionBase} from "../ActionBase.sol";
 /// @notice Morpho Blue markets are NOT ERC4626; this action interacts with the Morpho Blue
 ///         singleton contract directly using market-level supply/withdraw functions.
 /// @dev The Morpho Blue singleton address is read from AdminVault via _configAddress().
-///      Each whitelisted market's loan token is registered as a pool in AdminVault.
-///      The specific market is identified by a bytes32 marketId passed in calldata.
+///      Each market is whitelisted individually: marketKey = address(uint160(uint256(marketId)))
+///      is registered as a pool in AdminVault, so authorization binds the exact market
+///      (and therefore its full MarketParams), not just the shared loan token.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract MorphoMarketsWithdraw is ActionBase {
     using SafeERC20 for IERC20;
 
+    /// @notice Virtual shares/assets used by Morpho Blue's SharesMathLib for
+    ///         share<->asset conversion; mirroring them keeps our position
+    ///         valuation identical to what Morpho enforces on-chain.
+    uint256 private constant VIRTUAL_SHARES = 1e6;
+    uint256 private constant VIRTUAL_ASSETS = 1;
+
     /// @notice Parameters for the withdraw action
-    /// @param poolId Identifies the registered loan token in AdminVault
+    /// @param marketId The Morpho Blue market identifier (keccak256 of MarketParams); the whitelist unit
     /// @param feeBasis Fee percentage to apply (in basis points, e.g., 100 = 1%)
     /// @param amount Amount of underlying loan token to withdraw (type(uint256).max for full position)
     /// @param maxSharesBurned Maximum Morpho supply shares to burn (slippage protection)
-    /// @param marketId The Morpho Blue market identifier (keccak256 of MarketParams)
     struct Params {
-        bytes4 poolId;
+        bytes32 marketId;
         uint16 feeBasis;
         uint256 amount;
         uint256 maxSharesBurned;
-        bytes32 marketId;
     }
 
     constructor(address _adminVault, address _logger) ActionBase(_adminVault, _logger) {}
@@ -38,19 +43,26 @@ contract MorphoMarketsWithdraw is ActionBase {
         Params memory inputData = _parseInputs(_callData);
         ADMIN_VAULT.checkFeeBasis(inputData.feeBasis);
 
-        address loanToken = ADMIN_VAULT.getPoolAddress(protocolName(), inputData.poolId);
+        // Authorize the exact market: marketKey is derived from the marketId and must be a
+        // whitelisted pool. This binds approval to the full MarketParams, not the shared loan token.
+        address marketKey = address(uint160(uint256(inputData.marketId)));
+        bytes4 poolId = _poolIdFromAddress(marketKey);
+        require(
+            ADMIN_VAULT.getPoolAddress(protocolName(), poolId) == marketKey,
+            Errors.InvalidInput(protocolName(), "marketId")
+        );
+
         IMorphoBlue morpho = IMorphoBlue(_configAddress());
         Id id = Id.wrap(inputData.marketId);
         MarketParams memory marketParams = morpho.idToMarketParams(id);
-        require(marketParams.loanToken == loanToken, Errors.InvalidInput(protocolName(), "marketId"));
 
         (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) = _withdrawFromMarket(
-            inputData, morpho, id, marketParams
+            inputData, morpho, id, marketParams, marketKey
         );
 
         LOGGER.logActionEvent(
             LogType.BALANCE_UPDATE,
-            _encodeBalanceUpdate(_strategyId, inputData.poolId, sharesBefore, sharesAfter, feeInTokens)
+            _encodeBalanceUpdate(_strategyId, poolId, sharesBefore, sharesAfter, feeInTokens)
         );
     }
 
@@ -58,11 +70,12 @@ contract MorphoMarketsWithdraw is ActionBase {
         Params memory _inputData,
         IMorphoBlue _morpho,
         Id _id,
-        MarketParams memory _marketParams
+        MarketParams memory _marketParams,
+        address _marketKey
     ) private returns (uint256 sharesBefore, uint256 sharesAfter, uint256 feeInTokens) {
         sharesBefore = _morpho.position(_id, address(this)).supplyShares;
 
-        feeInTokens = _processMorphoFee(_morpho, _id, _marketParams, _inputData.feeBasis);
+        feeInTokens = _processMorphoFee(_morpho, _id, _marketParams, _marketKey, _inputData.feeBasis);
 
         uint256 sharesBurned;
 
@@ -108,7 +121,9 @@ contract MorphoMarketsWithdraw is ActionBase {
     }
 
     /// @notice Computes the maximum withdrawable amount from a Morpho Blue market
-    /// @dev Capped by both the user's position value and available market liquidity
+    /// @dev Capped by both the user's position value and available market liquidity.
+    ///      Position value uses Morpho's toAssetsDown (virtual shares, rounded down)
+    ///      so the cap is always achievable when Morpho rounds shares up on withdraw.
     function _getMaxWithdraw(
         IMorphoBlue _morpho,
         Id _id
@@ -117,22 +132,31 @@ contract MorphoMarketsWithdraw is ActionBase {
         if (pos.supplyShares == 0) return 0;
 
         Market memory mkt = _morpho.market(_id);
-        uint256 positionAssets = (pos.supplyShares * uint256(mkt.totalSupplyAssets)) / uint256(mkt.totalSupplyShares);
+        uint256 positionAssets = _toAssetsDown(pos.supplyShares, mkt);
         uint256 availableLiquidity = uint256(mkt.totalSupplyAssets) - uint256(mkt.totalBorrowAssets);
 
         return positionAssets < availableLiquidity ? positionAssets : availableLiquidity;
     }
 
+    /// @notice Converts supply shares to assets, matching Morpho Blue's
+    ///         SharesMathLib.toAssetsDown semantics
+    function _toAssetsDown(uint256 _shares, Market memory _mkt) private pure returns (uint256) {
+        return (_shares * (uint256(_mkt.totalSupplyAssets) + VIRTUAL_ASSETS))
+            / (uint256(_mkt.totalSupplyShares) + VIRTUAL_SHARES);
+    }
+
     /// @notice Processes fees for a Morpho Blue position by withdrawing underlying from the market
     /// @dev Morpho Blue positions are not ERC20 tokens, so fees are taken in the underlying
-    ///      loan token by partially withdrawing from the supply position.
+    ///      loan token by partially withdrawing from the supply position. The fee timestamp is
+    ///      keyed per-market (marketKey), so markets sharing a loan token accrue independently.
     function _processMorphoFee(
         IMorphoBlue _morpho,
         Id _id,
         MarketParams memory _marketParams,
+        address _marketKey,
         uint256 _feeBasis
     ) private returns (uint256 feeInTokens) {
-        address feeKey = _marketParams.loanToken;
+        address feeKey = _marketKey;
         uint256 lastFeeTimestamp = ADMIN_VAULT.getLastFeeTimestamp(feeKey);
 
         if (lastFeeTimestamp == 0) {
@@ -154,7 +178,7 @@ contract MorphoMarketsWithdraw is ActionBase {
         _morpho.accrueInterest(_marketParams);
         Market memory mkt = _morpho.market(_id);
 
-        uint256 positionAssets = (pos.supplyShares * uint256(mkt.totalSupplyAssets)) / uint256(mkt.totalSupplyShares);
+        uint256 positionAssets = _toAssetsDown(pos.supplyShares, mkt);
         uint256 fee = _calculateFee(positionAssets, _feeBasis, lastFeeTimestamp, currentTimestamp);
 
         // Record the fee timestamp before withdrawing/transferring the fee (checks-effects-interactions)

--- a/contracts/actions/morpho-markets/MorphoMarketsWithdraw.sol
+++ b/contracts/actions/morpho-markets/MorphoMarketsWithdraw.sol
@@ -157,13 +157,15 @@ contract MorphoMarketsWithdraw is ActionBase {
         uint256 positionAssets = (pos.supplyShares * uint256(mkt.totalSupplyAssets)) / uint256(mkt.totalSupplyShares);
         uint256 fee = _calculateFee(positionAssets, _feeBasis, lastFeeTimestamp, currentTimestamp);
 
+        // Record the fee timestamp before withdrawing/transferring the fee (checks-effects-interactions)
+        // so a callback-capable loan token cannot re-enter on a stale timestamp and collect twice.
+        ADMIN_VAULT.setFeeTimestamp(feeKey);
+
         if (fee > 0) {
             (uint256 actualFee,) = _morpho.withdraw(_marketParams, fee, 0, address(this), address(this));
             IERC20(_marketParams.loanToken).safeTransfer(ADMIN_VAULT.feeConfig().recipient, actualFee);
             feeInTokens = actualFee;
         }
-
-        ADMIN_VAULT.setFeeTimestamp(feeKey);
     }
 
     function _parseInputs(bytes memory _callData) private pure returns (Params memory inputData) {

--- a/contracts/actions/nexus-mutual/BuyCover.sol
+++ b/contracts/actions/nexus-mutual/BuyCover.sol
@@ -87,13 +87,18 @@ contract BuyCover is ActionBase {
             IERC20 paymentAsset = IERC20(_assetIdToTokenAddress(params.paymentAsset));
             uint256 balanceBefore = paymentAsset.balanceOf(address(this));
 
-            paymentAsset.safeIncreaseAllowance(address(COVER_BROKER), params.maxPremiumInAsset);
-            
+            // Approve the exact premium ceiling and clear it afterwards. The broker only pulls the
+            // actual premium (<= maxPremiumInAsset), so a strict set-then-clear prevents residual
+            // allowance from accumulating across cover purchases.
+            paymentAsset.forceApprove(address(COVER_BROKER), params.maxPremiumInAsset);
+
             coverId = COVER_BROKER.buyCover(params, poolAllocationRequests);
 
             uint256 balanceAfter = paymentAsset.balanceOf(address(this));
-            
+
             premiumPaid = balanceBefore - balanceAfter;
+
+            paymentAsset.forceApprove(address(COVER_BROKER), 0);
         }
 
         return (params.period, params.amount, premiumPaid, coverId);

--- a/contracts/actions/spark-savings-v2/SparkSavingsV2Supply.sol
+++ b/contracts/actions/spark-savings-v2/SparkSavingsV2Supply.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.28;
+
+import {ERC4626Supply} from "../common/ERC4626Supply.sol";
+
+/// @title SparkSavingsV2Supply - Supplies tokens to a Spark Savings vault
+/// @notice This contract allows users to supply tokens to a Spark Savings vault (e.g., Spark Savings USDC / USDT)
+/// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
+contract SparkSavingsV2Supply is ERC4626Supply {
+    /// @notice Initializes the SparkSavingsV2Supply contract
+    /// @param _adminVault Address of the admin vault
+    /// @param _logger Address of the logger contract
+    constructor(address _adminVault, address _logger) ERC4626Supply(_adminVault, _logger) {}
+
+    /// @inheritdoc ERC4626Supply
+    function protocolName() public pure override returns (string memory) {
+        return "SparkSavingsV2";
+    }
+}

--- a/contracts/actions/spark-savings-v2/SparkSavingsV2Withdraw.sol
+++ b/contracts/actions/spark-savings-v2/SparkSavingsV2Withdraw.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.28;
+
+import {ERC4626Withdraw} from "../common/ERC4626Withdraw.sol";
+
+/// @title SparkSavingsV2Withdraw - Withdraws tokens from a Spark Savings vault
+/// @notice This contract allows users to withdraw tokens from a Spark Savings vault (e.g., Spark Savings USDC / USDT)
+/// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
+contract SparkSavingsV2Withdraw is ERC4626Withdraw {
+    /// @notice Initializes the SparkSavingsV2Withdraw contract
+    /// @param _adminVault Address of the admin vault
+    /// @param _logger Address of the logger contract
+    constructor(address _adminVault, address _logger) ERC4626Withdraw(_adminVault, _logger) {}
+
+    /// @inheritdoc ERC4626Withdraw
+    function protocolName() public pure override returns (string memory) {
+        return "SparkSavingsV2";
+    }
+}

--- a/contracts/actions/swap/ParaswapSwap.sol
+++ b/contracts/actions/swap/ParaswapSwap.sol
@@ -87,45 +87,73 @@ contract ParaswapSwap is ActionBase {
         // _strategyId is ignored, as this action is not strategy-specific
         _strategyId;
 
-        // Extract the destination token from swapCallData
-        address extractedDestToken = extractSwapDestination(params.swapCallData);
+        // Decode both the source and destination tokens from swapCallData
+        (address extractedSrcToken, address extractedDestToken) = extractSwapTokens(params.swapCallData);
 
-        // Verify the destination token is approved in the registry
+        // Verify the input token is approved and matches the declared tokenIn. This pins the asset
+        // the router is allowed to spend to the one the Safe approved, even if a residual allowance exists.
+        require(
+            TOKEN_REGISTRY.isApprovedToken(params.tokenIn),
+            Errors.Paraswap__TokenNotApproved(params.tokenIn)
+        );
+        require(
+            extractedSrcToken == params.tokenIn,
+            Errors.Paraswap__SourceTokenMismatch(params.tokenIn, extractedSrcToken)
+        );
+
+        // Verify the destination token is approved and matches the declared tokenOut
         require(
             TOKEN_REGISTRY.isApprovedToken(extractedDestToken),
             Errors.Paraswap__TokenNotApproved(extractedDestToken)
         );
-        
-        // Validate the extracted destination token against our expectations
         require(
             extractedDestToken == params.tokenOut,
             Errors.Paraswap__TokenMismatch(params.tokenOut, extractedDestToken)
         );
-        
+
         // Execute the swap
         _paraswapSwap(params);
+    }
+
+    /// @notice Extracts the source token from swap call data
+    /// @param _swapCallData The calldata for the swap
+    /// @return The extracted source token address
+    function extractSwapSource(bytes memory _swapCallData) public pure returns (address) {
+        (address srcToken, ) = extractSwapTokens(_swapCallData);
+        return srcToken;
     }
 
     /// @notice Extracts the destination token from swap call data
     /// @param _swapCallData The calldata for the swap
     /// @return The extracted destination token address
     function extractSwapDestination(bytes memory _swapCallData) public pure returns (address) {
+        (, address destToken) = extractSwapTokens(_swapCallData);
+        return destToken;
+    }
+
+    /// @notice Decodes the source and destination tokens from Augustus swap calldata
+    /// @param _swapCallData The calldata for the swap
+    /// @return srcToken The source token the router will spend
+    /// @return destToken The destination token the router will return
+    /// @dev Every supported Augustus swap struct lays out srcToken immediately before destToken,
+    ///      so the source address sits exactly one 32-byte word ahead of the destination address.
+    function extractSwapTokens(bytes memory _swapCallData) public pure returns (address srcToken, address destToken) {
         // Make sure we have enough data to extract the selector
         require(_swapCallData.length >= 4, Errors.Paraswap__InvalidCalldata());
-        
+
         // Extract the function selector from the first 4 bytes
-        bytes4 selector = bytes4(_swapCallData[0]) | (bytes4(_swapCallData[1]) >> 8) | 
+        bytes4 selector = bytes4(_swapCallData[0]) | (bytes4(_swapCallData[1]) >> 8) |
                           (bytes4(_swapCallData[2]) >> 16) | (bytes4(_swapCallData[3]) >> 24);
-        
-        // Default position for data extraction
+
+        // Position of the destination token word, measured from the start of the calldata
         uint256 destTokenPosition;
-        
+
         // Set position based on function selector
         if (selector == SWAP_EXACT_AMOUNT_IN_SELECTOR) {
             // swapExactAmountIn
             destTokenPosition = 68;
         } else if (selector == UNISWAP_V3_SWAP_SELECTOR) {
-            // swapExactAmountInOnUniswapV3 
+            // swapExactAmountInOnUniswapV3
             destTokenPosition = 132;
         } else if (selector == CURVE_V1_SWAP_SELECTOR) {
             // swapExactAmountInOnCurveV1
@@ -143,19 +171,21 @@ contract ParaswapSwap is ActionBase {
             // Unknown selector, revert
             revert Errors.Paraswap__UnsupportedSelector(selector);
         }
-        
-        // Extract the destination token
-        address destToken;
-        
+
+        // srcToken is encoded one 32-byte word before destToken in every supported struct
+        uint256 srcTokenPosition = destTokenPosition - 32;
+
+        // Ensure the calldata is long enough to read the destination word in full; this also
+        // covers the earlier source word, preventing out-of-bounds reads on truncated calldata
+        require(_swapCallData.length >= destTokenPosition + 32, Errors.Paraswap__InvalidCalldata());
+
         assembly {
             // The actual data in _swapCallData starts at memory position add(_swapCallData, 32)
             let dataPtr := add(_swapCallData, 32)
-            
-            // Extract the destination token address at the specified position
+
+            srcToken := and(mload(add(dataPtr, srcTokenPosition)), 0xffffffffffffffffffffffffffffffffffffffff)
             destToken := and(mload(add(dataPtr, destTokenPosition)), 0xffffffffffffffffffffffffffffffffffffffff)
         }
-        
-        return destToken;
     }
 
     /// @notice Executes the Paraswap swap
@@ -172,8 +202,10 @@ contract ParaswapSwap is ActionBase {
         IERC20 tokenIn = IERC20(_params.tokenIn);
         IERC20 tokenOut = IERC20(_params.tokenOut);
 
-        // Approve spending of input token
-        tokenIn.safeIncreaseAllowance(address(AUGUSTUS_ROUTER), _params.fromAmount);
+        // Approve the router for exactly the input amount. Augustus routes can leave part of the
+        // input unspent, so a strict set-then-clear avoids residual allowances accumulating across
+        // swaps and stays compatible with tokens that require a zero reset (e.g. USDT).
+        tokenIn.forceApprove(address(AUGUSTUS_ROUTER), _params.fromAmount);
 
         // Record balance before swap
         uint256 balanceBefore = tokenOut.balanceOf(address(this));
@@ -195,6 +227,9 @@ contract ParaswapSwap is ActionBase {
             amountReceived >= _params.minToAmount,
             Errors.Paraswap__InsufficientOutput(amountReceived, _params.minToAmount)
         );
+
+        // Clear any allowance left unused by the router
+        tokenIn.forceApprove(address(AUGUSTUS_ROUTER), 0);
 
         LOGGER.logActionEvent(
             LogType.PARASWAP_SWAP,

--- a/contracts/actions/swap/ZeroExSwap.sol
+++ b/contracts/actions/swap/ZeroExSwap.sol
@@ -51,6 +51,10 @@ contract ZeroExSwap is ActionBase {
         _strategyId;
 
         require(
+            TOKEN_REGISTRY.isApprovedToken(params.tokenIn),
+            Errors.ZeroEx__TokenNotApproved(params.tokenIn)
+        );
+        require(
             TOKEN_REGISTRY.isApprovedToken(params.tokenOut),
             Errors.ZeroEx__TokenNotApproved(params.tokenOut)
         );

--- a/contracts/actions/utils/AssignToken.sol
+++ b/contracts/actions/utils/AssignToken.sol
@@ -21,6 +21,10 @@ contract AssignToken is ActionBase {
     /// @param token Address of the token to assign
     /// @param balanceBefore Previous cumulative balance for this strategy (provided by ts-client)
     /// @param balanceAfter New cumulative balance for this strategy
+    /// @dev `balanceBefore` is trusted off-chain input: it represents the indexer's prior cumulative
+    ///      balance for which there is no on-chain source of truth, so it is emitted for delta
+    ///      accounting only and is not validated here. `balanceAfter` is the only field checked
+    ///      against the Safe's actual holdings. Submitting this action requires an authorised signer.
     struct Params {
         address token;
         uint256 balanceBefore;

--- a/contracts/actions/utils/GasRefundAction.sol
+++ b/contracts/actions/utils/GasRefundAction.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Errors} from "../../Errors.sol";
 import {ActionBase} from "../ActionBase.sol";
 import {IEip712TypedDataSafeModule} from "../../interfaces/IEip712TypedDataSafeModule.sol";
 
@@ -20,6 +21,7 @@ contract GasRefundAction is ActionBase {
         address _logger,
         address _eip712Module
     ) ActionBase(_adminVault, _logger) {
+        require(_eip712Module != address(0), Errors.InvalidInput("GasRefundAction", "constructor"));
         EIP712_MODULE = IEip712TypedDataSafeModule(_eip712Module);
     }
 

--- a/contracts/actions/utils/GasRefundAction.sol
+++ b/contracts/actions/utils/GasRefundAction.sol
@@ -37,11 +37,16 @@ contract GasRefundAction is ActionBase {
         if (balance == 0) return;
         uint256 amount = balance < p.maxRefundAmount ? balance : p.maxRefundAmount;
         if (amount == 0) return;
+
+        // Log the amount the module actually receives so a fee-on-transfer refund token can't
+        // make the on-chain telemetry diverge from the module's real balance.
+        uint256 moduleBalanceBefore = IERC20(refundToken).balanceOf(address(EIP712_MODULE));
         IERC20(refundToken).safeTransfer(address(EIP712_MODULE), amount);
+        uint256 amountReceived = IERC20(refundToken).balanceOf(address(EIP712_MODULE)) - moduleBalanceBefore;
 
         LOGGER.logActionEvent(
             LogType.GAS_REFUND_RESERVATION,
-            abi.encode(refundToken, address(EIP712_MODULE), amount)
+            abi.encode(refundToken, address(EIP712_MODULE), amountReceived)
         );
     }
 

--- a/contracts/actions/utils/PullToken.sol
+++ b/contracts/actions/utils/PullToken.sol
@@ -3,12 +3,18 @@ pragma solidity =0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Errors} from "../../Errors.sol";
 import {ActionBase} from "../ActionBase.sol";
 
 /// @title Helper action to pull a token from the specified address
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract PullToken is ActionBase {
     using SafeERC20 for IERC20;
+
+    /// @notice The address of this implementation, captured at deployment
+    /// @dev Used by `onlyDelegateCall` to ensure the action only runs in a Safe's delegatecall context
+    address private immutable SELF = address(this);
+
     /// @param tokenAddr Address of token
     /// @param from From where the tokens are pulled
     /// @param amount Amount of tokens, can be type(uint).max
@@ -18,10 +24,16 @@ contract PullToken is ActionBase {
         uint256 amount;
     }
 
+    /// @notice Restricts execution to delegatecall context (address(this) is the Safe, not the implementation)
+    modifier onlyDelegateCall() {
+        require(address(this) != SELF, Errors.PullToken__OnlyDelegateCall());
+        _;
+    }
+
     constructor(address _adminVault, address _logger) ActionBase(_adminVault, _logger) {}
 
     /// @inheritdoc ActionBase
-    function executeAction(bytes memory _callData, uint16 /*_strategyId*/) public payable override {
+    function executeAction(bytes memory _callData, uint16 /*_strategyId*/) public payable override onlyDelegateCall {
         Params memory inputData = _parseInputs(_callData);
 
         _pullToken(inputData.tokenAddr, inputData.from, inputData.amount);

--- a/contracts/actions/utils/UpgradeAction.sol
+++ b/contracts/actions/utils/UpgradeAction.sol
@@ -128,7 +128,7 @@ contract UpgradeAction is ActionBase {
 
     /// @inheritdoc ActionBase
     function actionType() public pure override returns (uint8) {
-        return uint8(ActionType.CUSTOM_ACTION);
+        return uint8(ActionType.UPGRADE_ACTION);
     }
 
     /// @inheritdoc ActionBase

--- a/contracts/actions/utils/gas/CommonGasPriceAdaptor.sol
+++ b/contracts/actions/utils/gas/CommonGasPriceAdaptor.sol
@@ -32,11 +32,28 @@ abstract contract CommonGasPriceAdaptor is IGasPriceAdaptor {
     /// @return valid True if valid token configuration
     function _getConversionExponent(address refundToken) internal view returns (uint256 exponent, bool valid) {
         uint256 oracleDecimals = IAggregatorV3(ethUsdOracle).decimals();
-        uint256 tokenDecimals = IERC20Metadata(refundToken).decimals();
-        if (tokenDecimals > 18 + oracleDecimals) {
+        (uint256 tokenDecimals, bool hasDecimals) = _tryGetTokenDecimals(refundToken);
+        if (!hasDecimals || tokenDecimals > 18 + oracleDecimals) {
             return (0, false);
         }
         return (18 + oracleDecimals - tokenDecimals, true);
+    }
+
+    /// @notice Read a refund token's `decimals()` without reverting. A token that omits `decimals()`,
+    ///         reverts, or returns malformed data yields `valid = false`, so the refund degrades to
+    ///         zero rather than reverting the whole bundle.
+    /// @param refundToken Token address to query.
+    /// @return decimals The token decimals (0 when invalid).
+    /// @return valid True when a well-formed `decimals()` value was returned.
+    function _tryGetTokenDecimals(address refundToken) private view returns (uint256 decimals, bool valid) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory data) = refundToken.staticcall(
+            abi.encodeWithSelector(IERC20Metadata.decimals.selector)
+        );
+        if (!success || data.length < 32) {
+            return (0, false);
+        }
+        return (abi.decode(data, (uint8)), true);
     }
 
     /// @notice Convert wei amount to token amount using ETH/USD price

--- a/contracts/auth/AuthRegistry.sol
+++ b/contracts/auth/AuthRegistry.sol
@@ -1,38 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.28;
 
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {Errors} from "../Errors.sol";
-import {IActionBase} from "../interfaces/IActionBase.sol";
-import {IBravaSafeModule} from "../interfaces/IBravaSafeModule.sol";
-import {IEip712TypedDataSafeModule as ITyped} from "../interfaces/IEip712TypedDataSafeModule.sol";
+import {IAuthRegistry} from "../interfaces/IAuthRegistry.sol";
 import {ILogger} from "../interfaces/ILogger.sol";
-import {IMessageTransmitterV2} from "../interfaces/IMessageTransmitterV2.sol";
-import {ISafe} from "../interfaces/safe/ISafe.sol";
+import {IOwnerManager} from "../interfaces/safe/IOwnerManager.sol";
 import {ISafeDeployment} from "../interfaces/ISafeDeployment.sol";
-
-import {BravaModuleLookup} from "../libraries/BravaModuleLookup.sol";
+import {EIP712TypedDataLib} from "../libraries/EIP712TypedDataLib.sol";
 
 /// @title AuthRegistry
 /// @author Brava Finance
 /// @notice Per-chain registry of authorised managers, co-signers, and co-signing thresholds per Safe,
 ///         plus a monotonic version counter. Canonical state consulted by the EIP-712 module's signer gate.
-/// @dev Three write paths share the same `_apply` enforcement (length cap, zero/duplicate checks,
-///      version-monotonic with idempotent equality, threshold validation):
-///        1. `setAuthConfig`            — module-only; caller must currently be enabled as a module
-///                                        on the target Safe. Survives module upgrades because the
-///                                        registry never binds to a single module address.
-///        2. `receiveCCTPAuthUpdate`    — permissionless; verifies a Circle attestation and
-///                                        triple-checks burnSender == hookSafe == mintRecipient
-///                                        before applying the snapshot. No bundle execution.
-///        3. `relayCCTPAndExecute`      — permissionless; same trust path as (2), then best-effort
-///                                        forwards an EIP-712-signed bundle to the destination
-///                                        Safe's currently-enabled Brava module (discovered via
-///                                        ERC-165). Combines fund mint, auth propagation, and
-///                                        bundle execution into a single attested message.
+/// @dev The single write path is `applyAuthBundle`: a permissionless relayer entry that verifies an
+///      Owner-signed EIP-712 `AuthBundle` against the chain-agnostic domain (chainId=1,
+///      verifyingContract=Safe) and snapshot-replaces the config via `_apply` (length cap,
+///      zero/duplicate checks, version-monotonic with idempotent equality, threshold validation).
+///      Because the domain binds to the Safe — not to this registry or the module — the same signed
+///      payload is relayable on every chain, including chains added after signing, and survives
+///      module or registry redeployment.
+/// @dev When the Safe is not yet deployed on this chain, ownership is proven by matching the
+///      signer's deterministic CREATE2 Safe address (`predictSafeAddress`). This allows auth config
+///      to land before the Safe lazily deploys during its first bundle execution.
 /// @notice Auth-config state changes are logged via the shared Logger (logId 209).
-///         CCTP relay outcomes are logged separately via LogType.CCTP_RELAY_AND_EXECUTE.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract AuthRegistry {
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -43,39 +36,28 @@ contract AuthRegistry {
     /// @notice Hard cap on the number of co-signers per Safe.
     uint256 public constant MAX_COSIGNERS_PER_SAFE = 10;
 
+    /// @notice Largest forward gap allowed between the current and the applied auth version. Versions
+    ///         may skip ahead (a chain that missed an intermediate version need not replay it) but not
+    ///         by more than this, which bounds how fast the version space can be consumed: exhausting
+    ///         it would take on the order of `type(uint256).max / MAX_VERSION_INCREASE` applications.
+    uint256 public constant MAX_VERSION_INCREASE = 10;
+
     /// @notice AdminVaultEvent logId emitted on every state mutation.
     uint256 private constant LOG_ID_AUTH_CONFIG_UPDATED = 209;
 
-    /// @notice CCTP V2 message header size in bytes.
-    uint256 private constant MESSAGE_HEADER_SIZE = 148;
-
-    /// @notice CCTP V2 BurnMessage fixed-fields size in bytes (preceding the optional hookData).
-    uint256 private constant BURN_MESSAGE_FIXED_SIZE = 228;
-
-    /// @notice Byte offset of the source-domain field within a CCTP V2 message.
-    uint256 private constant SOURCE_DOMAIN_OFFSET = 4;
-
-    /// @notice Byte offset of the nonce field within a CCTP V2 message (bytes32).
-    uint256 private constant NONCE_OFFSET = 12;
-
-    /// @notice Byte offset of `BurnMessage.mintRecipient` within a CCTP V2 message.
-    uint256 private constant BURN_MINT_RECIPIENT_OFFSET = 184;
-
-    /// @notice Byte offset of `BurnMessage.messageSender` (the burner) within a CCTP V2 message.
-    uint256 private constant BURN_MESSAGE_SENDER_OFFSET = 248;
-
-    /// @notice Minimum valid hook envelope size: `abi.encode(uint8, bytes)` with empty bytes payload
-    ///         occupies 3 head words (hookVersion, offset, length).
-    uint256 private constant HOOK_ENVELOPE_MIN_SIZE = 96;
+    /// @notice Length of a single packed ECDSA signature (r[32] || s[32] || v[1]).
+    uint256 private constant SIGNATURE_LENGTH = 65;
 
     /// @notice Logger contract receiving all auth config update events.
     ILogger public immutable LOGGER;
 
-    /// @notice Circle MessageTransmitter V2 — sole trusted source for cross-chain auth updates.
-    address public immutable MESSAGE_TRANSMITTER;
-
-    /// @notice Safe factory for deterministic CREATE2 deployment in the relay path.
+    /// @notice Safe factory used to prove ownership of not-yet-deployed Safes via CREATE2 prediction.
     ISafeDeployment public immutable SAFE_DEPLOYMENT;
+
+    /// @notice EIP-712 domain name used in the domain separator.
+    string public domainName;
+    /// @notice EIP-712 domain version used in the domain separator.
+    string public domainVersion;
 
     struct AuthConfig {
         uint256 version;
@@ -89,297 +71,86 @@ contract AuthRegistry {
     ///         A zero bitmap means unrestricted (manager can execute any action type).
     mapping(address safe => mapping(address manager => uint256)) private _actionTypeBitmaps;
 
-    /// @notice Initializes the registry with its logger, Circle transmitter, and Safe deployment helper.
-    /// @param _logger Logger contract receiving auth config update and relay events.
-    /// @param _messageTransmitter Circle MessageTransmitter V2 used to verify CCTP messages.
-    /// @param _safeDeployment Safe deployment helper used for optimistic relay-time Safe deployment.
-    constructor(address _logger, address _messageTransmitter, address _safeDeployment) {
+    /// @notice Initializes the registry with its logger, Safe deployment helper, and EIP-712 domain.
+    /// @param _logger Logger contract receiving auth config update events.
+    /// @param _safeDeployment Safe deployment helper used for CREATE2 owner verification.
+    /// @param _domainName EIP-712 domain name (must match the bundle-executing module's domain).
+    /// @param _domainVersion EIP-712 domain version (must match the bundle-executing module's domain).
+    constructor(
+        address _logger,
+        address _safeDeployment,
+        string memory _domainName,
+        string memory _domainVersion
+    ) {
         require(
-            _logger != address(0) && _messageTransmitter != address(0) && _safeDeployment != address(0),
+            _logger != address(0) &&
+                _safeDeployment != address(0) &&
+                bytes(_domainName).length > 0 &&
+                bytes(_domainVersion).length > 0,
             "Invalid input"
         );
         LOGGER = ILogger(_logger);
-        MESSAGE_TRANSMITTER = _messageTransmitter;
         SAFE_DEPLOYMENT = ISafeDeployment(_safeDeployment);
+        domainName = _domainName;
+        domainVersion = _domainVersion;
     }
 
     // =============================
-    // Path 1 — owner-signed bundle (via module)
+    // Write path — Owner-signed AuthBundle
     // =============================
-    /// @notice Replaces the full auth config for a Safe at a new version. Intended caller is the
-    ///         EIP-712 module after it has verified the bundle signer is an Owner of the Safe.
+    /// @notice Verifies an Owner-signed EIP-712 AuthBundle and snapshot-replaces the Safe's auth
+    ///         config at the carried version. Permissionless: the signature, not the caller,
+    ///         carries the authority, so any relayer can submit a stored bundle on any chain.
+    /// @dev Replay semantics are intentional and version-bound: the same signature applies the same
+    ///      snapshot on every chain (idempotent at equal version) and becomes inert everywhere once
+    ///      a higher version exists (`_apply` reverts stale versions). Ownership is checked against
+    ///      the live Safe owner list, so a signature from a removed owner stops verifying.
     /// @param _safe Safe whose auth config is being replaced.
-    /// @param _newVersion Monotonic config version to apply.
-    /// @param _newManagers Complete replacement manager set.
-    /// @param _newCoSigners Complete replacement co-signer set.
-    /// @param _managerCoSignThreshold Number of co-signers required for manager-signed bundles.
-    /// @param _managerRestrictions Per-manager action type restrictions (only restricted managers listed).
-    function setAuthConfig(
+    /// @param _bundle Owner-signed auth bundle (expiry + full config snapshot).
+    /// @param _signature Single packed 65-byte ECDSA signature (r[32] || s[32] || v[1]) by a Safe owner.
+    function applyAuthBundle(
         address _safe,
-        uint256 _newVersion,
-        address[] calldata _newManagers,
-        address[] calldata _newCoSigners,
-        uint256 _managerCoSignThreshold,
-        ITyped.ManagerRestriction[] calldata _managerRestrictions
+        IAuthRegistry.AuthBundle calldata _bundle,
+        bytes calldata _signature
     ) external {
-        if (!ISafe(_safe).isModuleEnabled(msg.sender)) {
-            revert Errors.AuthRegistry_NotEnabledModule(_safe, msg.sender);
+        if (_bundle.expiry < block.timestamp + 1) {
+            revert Errors.AuthRegistry_BundleExpired();
         }
-        _apply(_safe, _newVersion, _newManagers, _newCoSigners, _managerCoSignThreshold, _managerRestrictions);
-    }
-
-    // =============================
-    // Path 2 — CCTP cross-chain copy (permissionless relay, no bundle)
-    // =============================
-    /// @notice Receives a Circle-attested CCTP V2 message carrying an auth config snapshot from the
-    ///         source chain and copies it locally.
-    /// @param _message Encoded CCTP V2 message containing the burn message and optional hook data.
-    /// @param _attestation Circle attestation proving the message was finalized.
-    function receiveCCTPAuthUpdate(
-        bytes calldata _message,
-        bytes calldata _attestation
-    ) external {
-        (bytes32 burnSender, bytes32 mintRecipient, bytes calldata hookData) = _parseCCTPMessage(_message);
-
-        if (!IMessageTransmitterV2(MESSAGE_TRANSMITTER).receiveMessage(_message, _attestation)) {
-            revert Errors.AuthRegistry_CCTPRelayFailed();
+        if (_signature.length != SIGNATURE_LENGTH) {
+            revert Errors.AuthRegistry_InvalidSignatureLength(_signature.length);
         }
 
-        _applyHookSnapshot(hookData, burnSender, mintRecipient);
-    }
+        bytes32 digest = EIP712TypedDataLib.hashAuthBundleForSigning(domainName, domainVersion, _safe, _bundle);
+        address signer = ECDSA.recover(digest, _signature);
 
-    // =============================
-    // Path 3 — combined CCTP relay + bundle execution
-    // =============================
-    /// @notice Mints USDC, optionally applies an auth config snapshot from `_message`'s hookData,
-    ///         and then best-effort executes `_bundle` through the destination Safe's currently-enabled
-    ///         Brava module.
-    /// @param _message Encoded CCTP V2 message containing the mint recipient and optional hook data.
-    /// @param _attestation Circle attestation proving the message was finalized.
-    /// @param _safe Destination Safe expected to receive the minted funds and execute the bundle.
-    /// @param _ownerAddress Owner EOA for optimistic Safe deployment. If non-zero and the Safe
-    ///        doesn't exist yet, the relay deploys it after auth apply and before bundle execution.
-    ///        Verified via `predictSafeAddress(ownerAddress) == _safe`. Pass `address(0)` to skip.
-    /// @param _bundle EIP-712 bundle forwarded to the enabled Brava module.
-    /// @param _signatures Signatures authorizing `_bundle` execution.
-    /// @return authApplied True when hook data contained and applied an auth snapshot.
-    /// @return bundleSuccess True when a Brava module was found and executed `_bundle` without reverting.
-    /// @return bundleReturnData Revert data returned by the Brava module when bundle execution fails.
-    function relayCCTPAndExecute(
-        bytes calldata _message,
-        bytes calldata _attestation,
-        address _safe,
-        address _ownerAddress,
-        ITyped.Bundle calldata _bundle,
-        bytes calldata _signatures
-    ) external returns (bool authApplied, bool bundleSuccess, bytes memory bundleReturnData) {
-        (bytes32 cctpNonce, uint32 sourceDomain) = _decodeMessageMetadata(_message);
-        _assertSafeMatchesMintRecipient(_message, _safe);
-        authApplied = _receiveAndMaybeApply(_message, _attestation);
+        _assertSignerIsOwner(_safe, signer);
 
-        if (_ownerAddress != address(0)) {
-            _optimisticDeploySafe(_safe, _ownerAddress);
-        }
-
-        address module;
-        (module, bundleSuccess, bundleReturnData) = _executeBundleBestEffort(_safe, _bundle, _signatures);
-
-        LOGGER.logActionEvent(
-            IActionBase.LogType.CCTP_RELAY_AND_EXECUTE,
-            abi.encode(_safe, module, authApplied, bundleSuccess, sourceDomain, cctpNonce)
+        _apply(
+            _safe,
+            _bundle.authUpdate.newVersion,
+            _bundle.authUpdate.newManagers,
+            _bundle.authUpdate.newCoSigners,
+            _bundle.authUpdate.managerCoSignThreshold,
+            _bundle.authUpdate.managerRestrictions
         );
     }
 
-    /// @notice Deploys a Safe when the relay can prove the supplied owner derives the target address.
-    /// @dev Deploys the Safe if it doesn't exist, after verifying the owner address produces the
-    ///      expected Safe address via CREATE2.
-    /// @param _safe Safe address that must match the deployment helper's prediction.
-    /// @param _ownerAddress Owner EOA used by the deployment helper to derive the Safe address.
-    function _optimisticDeploySafe(address _safe, address _ownerAddress) private {
-        address predicted = SAFE_DEPLOYMENT.predictSafeAddress(_ownerAddress);
-        if (predicted != _safe) {
-            revert Errors.AuthRegistry_SafeOwnerMismatch(_safe, _ownerAddress, predicted);
-        }
-        if (!SAFE_DEPLOYMENT.isSafeDeployed(_ownerAddress)) {
-            SAFE_DEPLOYMENT.deploySafe(_ownerAddress);
-        }
-    }
-
-    /// @notice Receives a CCTP message and applies its hook snapshot when one is present.
-    /// @dev Mints USDC via the Circle attestation and applies any hook-carried snapshot.
-    /// @param _message Encoded CCTP V2 message containing the burn message and optional hook data.
-    /// @param _attestation Circle attestation proving the message was finalized.
-    /// @return authApplied True when hook data contained and applied an auth snapshot.
-    function _receiveAndMaybeApply(
-        bytes calldata _message,
-        bytes calldata _attestation
-    ) private returns (bool authApplied) {
-        (bytes32 burnSender, bytes32 mintRecipient, bytes calldata hookData) = _parseCCTPMessage(_message);
-
-        if (!IMessageTransmitterV2(MESSAGE_TRANSMITTER).receiveMessage(_message, _attestation)) {
-            revert Errors.AuthRegistry_CCTPRelayFailed();
-        }
-
-        if (hookData.length > HOOK_ENVELOPE_MIN_SIZE - 1) {
-            _applyHookSnapshot(hookData, burnSender, mintRecipient);
-            authApplied = true;
-        }
-    }
-
-    /// @notice Attempts bundle execution through the Safe's currently enabled Brava module.
-    /// @dev Looks up the Safe's enabled Brava module via ERC-165 and forwards the bundle.
-    ///      Best-effort: if the module reverts (including ABI mismatch if the module's
-    ///      executeBundle signature changed — see IBravaSafeModule interfaceId coupling),
-    ///      bundleSuccess=false with revert data. Callers distinguish "no module" from
-    ///      "module reverted" via the module return value (address(0) vs non-zero).
-    /// @param _safe Safe whose enabled Brava module should execute the bundle.
-    /// @param _bundle EIP-712 bundle forwarded to the enabled Brava module.
-    /// @param _signatures Signatures authorizing `_bundle` execution.
-    /// @return module Enabled Brava module used for execution, or address(0) when none is found.
-    /// @return bundleSuccess True when a Brava module was found and executed `_bundle` without reverting.
-    /// @return bundleReturnData Revert data returned by the Brava module when bundle execution fails.
-    function _executeBundleBestEffort(
-        address _safe,
-        ITyped.Bundle calldata _bundle,
-        bytes calldata _signatures
-    ) private returns (address module, bool bundleSuccess, bytes memory bundleReturnData) {
-        bool found;
-        (found, module) = BravaModuleLookup.tryFindEnabledBravaModule(ISafe(_safe));
-        if (!found) {
-            return (address(0), false, "");
-        }
-        try IBravaSafeModule(module).executeBundle(_safe, _bundle, _signatures) {
-            bundleSuccess = true;
-        } catch (bytes memory err) {
-            bundleReturnData = err;
-        }
-    }
-
-    // =============================
-    // Internal: CCTP message parsing
-    // =============================
-    /// @notice Parses the CCTP V2 burn message fields needed by the registry.
-    /// @param _message Encoded CCTP V2 message containing a burn message.
-    /// @return burnSender Safe address encoded as the burn message sender.
-    /// @return mintRecipient Safe address encoded as the mint recipient.
-    /// @return hookData Optional hook payload appended to the burn message.
-    function _parseCCTPMessage(bytes calldata _message)
-        private
-        pure
-        returns (bytes32 burnSender, bytes32 mintRecipient, bytes calldata hookData)
-    {
-        uint256 hookDataOffset = MESSAGE_HEADER_SIZE + BURN_MESSAGE_FIXED_SIZE;
-        if (_message.length < hookDataOffset) {
-            revert Errors.AuthRegistry_HookMessageTooShort();
-        }
-
-        burnSender = bytes32(_message[BURN_MESSAGE_SENDER_OFFSET:BURN_MESSAGE_SENDER_OFFSET + 32]);
-        mintRecipient = bytes32(_message[BURN_MINT_RECIPIENT_OFFSET:BURN_MINT_RECIPIENT_OFFSET + 32]);
-        hookData = _message[hookDataOffset:];
-    }
-
-    /// @notice Decodes message header fields used for relay logging.
-    /// @dev CCTP V2 nonces are bytes32 (hashes, not counters). Stored as-is for event logging.
-    /// @param _message Encoded CCTP V2 message containing the header metadata.
-    /// @return cctpNonce CCTP nonce read from the message header.
-    /// @return sourceDomain Circle source domain read from the message header.
-    function _decodeMessageMetadata(bytes calldata _message)
-        private
-        pure
-        returns (bytes32 cctpNonce, uint32 sourceDomain)
-    {
-        sourceDomain = uint32(bytes4(_message[SOURCE_DOMAIN_OFFSET:SOURCE_DOMAIN_OFFSET + 4]));
-        cctpNonce = bytes32(_message[NONCE_OFFSET:NONCE_OFFSET + 32]);
-    }
-
-    /// @notice Requires the requested Safe to match the Circle-attested mint recipient.
-    /// @dev Asserts that the caller-supplied `_safe` matches the CCTP message's mintRecipient.
-    ///      This is a guardrail ensuring the caller targets the correct Safe — the actual mint
-    ///      destination is controlled solely by the Circle-attested message, not by this check.
-    /// @param _message Encoded CCTP V2 message containing the mint recipient.
-    /// @param _safe Safe address expected to match the message's mint recipient.
-    function _assertSafeMatchesMintRecipient(bytes calldata _message, address _safe) private pure {
-        bytes32 mintRecipient = bytes32(_message[BURN_MINT_RECIPIENT_OFFSET:BURN_MINT_RECIPIENT_OFFSET + 32]);
-        if (address(uint160(uint256(mintRecipient))) != _safe) {
-            revert Errors.AuthRegistry_SafeMintRecipientMismatch(_safe, mintRecipient);
-        }
-    }
-
-    /// @notice Applies the auth snapshot carried in a CCTP hook envelope.
-    /// @dev Decodes the hook envelope and applies the carried snapshot after enforcing the
-    ///      Safe-identity triple-check.
-    /// @param hookData ABI-encoded hook envelope carrying an auth snapshot.
-    /// @param burnSender Safe address encoded as the burn message sender.
-    /// @param mintRecipient Safe address encoded as the mint recipient.
-    function _applyHookSnapshot(
-        bytes calldata hookData,
-        bytes32 burnSender,
-        bytes32 mintRecipient
-    ) private {
-        if (hookData.length < HOOK_ENVELOPE_MIN_SIZE) revert Errors.AuthRegistry_BadHookEnvelope();
-        (uint8 hookVersion, bytes memory payload) = abi.decode(hookData, (uint8, bytes));
-        if (hookVersion != 1) revert Errors.AuthRegistry_UnknownHookVersion(hookVersion);
-
-        (
-            address safe,
-            uint256 newVersion,
-            address[] memory newManagers,
-            address[] memory newCoSigners,
-            uint256 managerCoSignThreshold,
-            uint256[] memory managerBitmaps
-        ) = abi.decode(payload, (address, uint256, address[], address[], uint256, uint256[]));
-
-        bytes32 safeAsBytes32 = bytes32(uint256(uint160(safe)));
-        if (burnSender != safeAsBytes32 || mintRecipient != safeAsBytes32) {
-            revert Errors.AuthRegistry_HookSafeMismatch(burnSender, mintRecipient, safe);
-        }
-
-        ITyped.ManagerRestriction[] memory restrictions = _bitmapsToRestrictions(newManagers, managerBitmaps);
-        _apply(safe, newVersion, newManagers, newCoSigners, managerCoSignThreshold, restrictions);
-    }
-
-    /// @notice Converts parallel arrays of managers and bitmaps into ManagerRestriction structs.
-    /// @dev Only managers with non-zero bitmaps produce a restriction entry.
-    function _bitmapsToRestrictions(
-        address[] memory _managers,
-        uint256[] memory _bitmaps
-    ) private pure returns (ITyped.ManagerRestriction[] memory) {
-        if (_managers.length != _bitmaps.length) {
-            revert Errors.AuthRegistry_BitmapLengthMismatch(_managers.length, _bitmaps.length);
-        }
-        uint256 restrictedCount;
-        for (uint256 i; i < _bitmaps.length; ++i) {
-            if (_bitmaps[i] != 0) ++restrictedCount;
-        }
-
-        ITyped.ManagerRestriction[] memory restrictions = new ITyped.ManagerRestriction[](restrictedCount);
-        uint256 idx;
-        for (uint256 i; i < _bitmaps.length; ++i) {
-            if (_bitmaps[i] == 0) continue;
-
-            uint256 bitCount;
-            uint256 temp = _bitmaps[i];
-            while (temp != 0) {
-                ++bitCount;
-                temp &= temp - 1;
+    /// @notice Requires the recovered signer to be an owner of the Safe.
+    /// @dev For a deployed Safe the live owner list is authoritative. For a not-yet-deployed Safe,
+    ///      ownership is proven by the signer's deterministic CREATE2 Safe address matching `_safe`
+    ///      — the same derivation the deployment factory uses, so no other EOA can produce it.
+    /// @param _safe Safe whose ownership is being checked.
+    /// @param _signer Recovered AuthBundle signer.
+    function _assertSignerIsOwner(address _safe, address _signer) private view {
+        if (_safe.code.length > 0) {
+            if (!IOwnerManager(_safe).isOwner(_signer)) {
+                revert Errors.AuthRegistry_SignerNotOwner(_safe, _signer);
             }
-
-            uint8[] memory actionTypes = new uint8[](bitCount);
-            uint256 writeIdx;
-            for (uint16 bit; bit < 256; ++bit) {
-                if ((_bitmaps[i] >> bit) & 1 == 1) {
-                    actionTypes[writeIdx++] = uint8(bit);
-                    if (writeIdx == bitCount) break;
-                }
-            }
-
-            restrictions[idx] = ITyped.ManagerRestriction({
-                manager: _managers[i],
-                allowedActionTypes: actionTypes
-            });
-            ++idx;
+            return;
         }
-        return restrictions;
+        if (SAFE_DEPLOYMENT.predictSafeAddress(_signer) != _safe) {
+            revert Errors.AuthRegistry_SignerNotOwner(_safe, _signer);
+        }
     }
 
     // =============================
@@ -404,7 +175,7 @@ contract AuthRegistry {
         address[] memory _newManagers,
         address[] memory _newCoSigners,
         uint256 _managerCoSignThreshold,
-        ITyped.ManagerRestriction[] memory _restrictions
+        IAuthRegistry.ManagerRestriction[] memory _restrictions
     ) internal {
         _validateSnapshot(_newVersion, _newManagers, _newCoSigners, _managerCoSignThreshold);
 
@@ -419,6 +190,12 @@ contract AuthRegistry {
                 revert Errors.AuthRegistry_ConflictingConfig(_newVersion);
             }
             return;
+        }
+        // _newVersion > currentVersion here, so the subtraction cannot underflow. Bounding the forward
+        // jump stops a single update from leaping to a near-`type(uint256).max` version that would
+        // leave no reachable higher version and freeze the auth config; gaps within the cap stay legal.
+        if (_newVersion - currentVersion > MAX_VERSION_INCREASE) {
+            revert Errors.AuthRegistry_VersionJumpTooLarge(currentVersion, _newVersion, MAX_VERSION_INCREASE);
         }
 
         uint256 oldLen = state.managers.length();
@@ -451,7 +228,7 @@ contract AuthRegistry {
     function _applyRestrictions(
         address _safe,
         address[] memory _newManagers,
-        ITyped.ManagerRestriction[] memory _restrictions
+        IAuthRegistry.ManagerRestriction[] memory _restrictions
     ) private {
         for (uint256 i; i < _newManagers.length; ++i) {
             _actionTypeBitmaps[_safe][_newManagers[i]] = 0;
@@ -488,6 +265,13 @@ contract AuthRegistry {
 
     /// @notice Validates the auth snapshot before it is compared with or written to storage.
     /// @dev Validates snapshot-level invariants that do not depend on existing registry state.
+    /// @dev A threshold of 0 with co-signers present is intentionally permitted: it registers a
+    ///      "dormant" co-signer set that does not yet gate manager bundles. This lets a new co-signer
+    ///      be onboarded (added to the Safe's config so their detection and signing can be exercised
+    ///      in simulation) without their signature becoming mandatory for live execution — so staged
+    ///      onboarding never blocks managers/testers. The threshold is raised in a later auth update
+    ///      once the co-signer is verified. Only an over-large threshold (more than the co-signer
+    ///      count) is rejected, since that would be permanently unsatisfiable.
     /// @param _newVersion Monotonic config version to apply.
     /// @param _newManagers Complete replacement manager set.
     /// @param _newCoSigners Complete replacement co-signer set.
@@ -572,7 +356,7 @@ contract AuthRegistry {
         address[] memory _managers,
         address[] memory _coSigners,
         uint256 _managerThreshold,
-        ITyped.ManagerRestriction[] memory _restrictions
+        IAuthRegistry.ManagerRestriction[] memory _restrictions
     ) internal view returns (bool) {
         if (state.managerCoSignThreshold != _managerThreshold) return false;
         if (!_setMatches(state.managers, _managers)) return false;
@@ -589,7 +373,7 @@ contract AuthRegistry {
     function _restrictionsMatch(
         address _safe,
         address[] memory _managers,
-        ITyped.ManagerRestriction[] memory _restrictions
+        IAuthRegistry.ManagerRestriction[] memory _restrictions
     ) private view returns (bool) {
         for (uint256 i; i < _managers.length; ++i) {
             uint256 expectedBitmap = 0;
@@ -692,5 +476,23 @@ contract AuthRegistry {
     /// @return The action type bitmap.
     function getManagerActionBitmap(address _safe, address _manager) external view returns (uint256) {
         return _actionTypeBitmaps[_safe][_manager];
+    }
+
+    /// @notice Computes the EIP-712 domain separator for a given Safe.
+    /// @param _safeAddr The Safe address used as the verifyingContract
+    /// @return The domain separator hash
+    function getDomainSeparator(address _safeAddr) external view returns (bytes32) {
+        return EIP712TypedDataLib.domainSeparator(domainName, domainVersion, _safeAddr);
+    }
+
+    /// @notice Computes the full EIP-712 signing hash for an auth bundle (domain separator + struct hash).
+    /// @param _safeAddr The Safe address used as verifyingContract in the domain
+    /// @param _bundle The auth bundle to hash
+    /// @return The digest that the Safe owner must sign
+    function getAuthBundleHash(
+        address _safeAddr,
+        IAuthRegistry.AuthBundle calldata _bundle
+    ) external view returns (bytes32) {
+        return EIP712TypedDataLib.hashAuthBundleForSigning(domainName, domainVersion, _safeAddr, _bundle);
     }
 }

--- a/contracts/auth/EIP712TypedDataSafeModule.sol
+++ b/contracts/auth/EIP712TypedDataSafeModule.sol
@@ -129,7 +129,9 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
             _feeRecipient != address(0) &&
             _usdcToken != address(0) &&
             _gasPriceAdaptor != address(0) &&
-            _authRegistry != address(0),
+            _authRegistry != address(0) &&
+            bytes(_domainName).length != 0 &&
+            bytes(_domainVersion).length != 0,
             "Invalid input"
         );
 

--- a/contracts/auth/EIP712TypedDataSafeModule.sol
+++ b/contracts/auth/EIP712TypedDataSafeModule.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.28;
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {Errors} from "../Errors.sol";
@@ -32,7 +33,7 @@ import {Enum} from "../libraries/Enum.sol";
 ///      `authUpdate`. The registry survives module upgrades, so re-deploying the module does not
 ///      lose auth state.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
-contract EIP712TypedDataSafeModule is ERC165 {
+contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     using ECDSA for bytes32;
     using SafeERC20 for IERC20;
 
@@ -159,6 +160,12 @@ contract EIP712TypedDataSafeModule is ERC165 {
     ///         thresholds → apply auth update → execute sequence.
     ///         Safe deployment is resolved before signer classification so that the classification
     ///         loop always operates on a deployed Safe with a real owner list and registry state.
+    /// @dev `nonReentrant` blocks any re-entry into bundle execution within the same transaction.
+    ///      The guard is contract-wide rather than per-Safe: legitimate concurrency across Safes
+    ///      happens in separate transactions (unaffected), and no in-protocol flow nests an
+    ///      `executeBundle` inside an executing sequence — the CCTP relay enters via its own
+    ///      top-level transaction. A manager-controlled action calling back into the module is
+    ///      therefore the only re-entry path, and it is rejected.
     /// @param _safeAddr The Safe address to execute on
     /// @param _bundle The bundle containing sequences for multiple chains and optional auth update
     /// @param _signatures Packed EIP-712 signatures sorted by signer address ascending.
@@ -167,7 +174,7 @@ contract EIP712TypedDataSafeModule is ERC165 {
         address _safeAddr,
         ITyped.Bundle calldata _bundle,
         bytes calldata _signatures
-    ) external onlyInitialized {
+    ) external nonReentrant onlyInitialized {
         uint256 gasStart = gasleft();
 
         if (_bundle.expiry < block.timestamp + 1) {

--- a/contracts/auth/EIP712TypedDataSafeModule.sol
+++ b/contracts/auth/EIP712TypedDataSafeModule.sol
@@ -233,6 +233,8 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
             _enforceManagerRestrictions(_safeAddr, managerAddr, targetSeq.sequence);
         }
 
+        _logBundleAuthorised(_safeAddr, _bundle, signers, coSignCount);
+
         _executeChainSequence(_safeAddr, _bundle, _signatures, expectedSequenceNonce, gasStart, targetSeq);
     }
 
@@ -463,7 +465,8 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
             );
         }
 
-        _logSequenceComplete(_safeAddr, _bundle.expiry, _expectedSequenceNonce);
+        bytes32 bundleHash = EIP712TypedDataLib.hashBundle(_bundle);
+        _logSequenceComplete(_safeAddr, _expectedSequenceNonce, bundleHash);
     }
 
     /// @notice Delegates a sequence execution call through the Safe's module interface.
@@ -623,14 +626,55 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
         _logFinalGasRefund(safe, paidAmount, recipient != address(0) ? recipient : safe);
     }
 
+    /// @notice Emits a BUNDLE_AUTHORISED audit-trail event naming who signed the bundle: the single
+    ///         authorising principal (owner or manager) and any co-signers. Emitted once per executed
+    ///         leg, carrying the same bundleHash as SEQUENCE_COMPLETE so off-chain indexers can
+    ///         attribute every leg of a bundle to its signers. Owner-vs-manager is resolved off-chain
+    ///         from registry/Safe state, so no on-chain role tag is emitted.
+    /// @dev Deliberately recomputes the bundle hash and re-queries co-signer status here instead of
+    ///      threading them out of executeBundle: a gas-for-clarity trade-off that keeps the audited
+    ///      signer-classification path untouched and avoids a stack-too-deep in executeBundle.
+    /// @param safe The Safe whose bundle was authorised
+    /// @param bundle The authorised bundle; its chain-independent struct hash is emitted so off-chain
+    ///        indexers share one correlation key across every leg of the bundle
+    /// @param signers The recovered signer set — already validated as owner, manager, or co-signer
+    /// @param coSignCount Number of co-signers among `signers`, used to size the co-signer array
+    function _logBundleAuthorised(
+        address safe,
+        ITyped.Bundle calldata bundle,
+        address[] memory signers,
+        uint256 coSignCount
+    ) internal {
+        bytes32 bundleHash = EIP712TypedDataLib.hashBundle(bundle);
+        address principal;
+        address[] memory coSigners = new address[](coSignCount);
+        uint256 filled;
+        for (uint256 i; i < signers.length; ++i) {
+            address signer = signers[i];
+            if (authRegistry.isCoSigner(safe, signer)) {
+                coSigners[filled] = signer;
+                ++filled;
+            } else {
+                principal = signer;
+            }
+        }
+        ILogger(ADMIN_VAULT.LOGGER()).logActionEvent(
+            IActionBase.LogType.BUNDLE_AUTHORISED,
+            abi.encode(safe, bundleHash, principal, coSigners)
+        );
+    }
+
     /// @notice Emits a SEQUENCE_COMPLETE log event via the AdminVault's logger.
-    /// @param safe The Safe that completed the sequence
-    /// @param expiry The bundle expiry timestamp
-    /// @param sequenceNonce The consumed sequence nonce
-    function _logSequenceComplete(address safe, uint256 expiry, uint256 sequenceNonce) internal {
+    /// @param safe The Safe that completed the sequence (the Logger records the module as caller,
+    ///        so the Safe address is only available here)
+    /// @param sequenceNonce The consumed sequence nonce — how far through the bundle this leg is
+    /// @param bundleHash Chain-independent bundle struct hash. Identical on every leg of the same
+    ///        bundle regardless of chain, so off-chain indexers can link all sequences that belong
+    ///        to one signed bundle — including the two sides of each cross-chain bridge pair.
+    function _logSequenceComplete(address safe, uint256 sequenceNonce, bytes32 bundleHash) internal {
         ILogger(ADMIN_VAULT.LOGGER()).logActionEvent(
             IActionBase.LogType.SEQUENCE_COMPLETE,
-            abi.encode(safe, expiry, block.chainid, sequenceNonce)
+            abi.encode(safe, sequenceNonce, bundleHash)
         );
     }
 

--- a/contracts/auth/EIP712TypedDataSafeModule.sol
+++ b/contracts/auth/EIP712TypedDataSafeModule.sol
@@ -28,10 +28,10 @@ import {Enum} from "../libraries/Enum.sol";
 ///         Verifies packed multi-signatures against Safe owners, co-signers, and managers
 ///         (sourced from AuthRegistry) and forwards validated sequences to the sequence executor.
 ///         Includes optional gas refund functionality with economic protections.
-/// @dev Auth state is owned by the per-chain AuthRegistry. The module reads from the registry for
-///      the signer gate and writes through the registry when an Owner-signed bundle carries an
-///      `authUpdate`. The registry survives module upgrades, so re-deploying the module does not
-///      lose auth state.
+/// @dev Auth state is owned by the per-chain AuthRegistry. The module only reads from the registry
+///      for the signer gate; auth config is written exclusively through the registry's own
+///      Owner-signed AuthBundle path. The registry survives module upgrades, so re-deploying the
+///      module does not lose auth state.
 /// @notice Found a vulnerability? Please contact security@brava.finance - we appreciate responsible disclosure and reward ethical hackers
 contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     using ECDSA for bytes32;
@@ -80,6 +80,18 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     uint256 public gasRefundOverhead;
     /// @notice Address of the gas price adaptor contract providing refund rate quotes.
     address public gasPriceAdaptor;
+
+    /// @notice Trusted CCTP relay entry point. When this address is the caller of `executeBundle`,
+    ///         the refund includes `cctpRelayOverhead` to cover gas spent before this module captures
+    ///         its `gasStart` snapshot — CCTP message validation, Circle's `receiveMessage` mint, and
+    ///         Brava module discovery. Settable post-deploy by the AdminVault owner so the relay entry
+    ///         can be retargeted without redeploying the module.
+    address public cctpBundleReceiver;
+
+    /// @notice Extra fixed gas allowance refunded on the CCTP relay path (see `cctpBundleReceiver`).
+    ///         Approximate by design — dominated by Circle's `receiveMessage` — and the per-bundle
+    ///         `maxRefundAmount` still caps total payout. Calibrate per chain.
+    uint256 public cctpRelayOverhead;
 
     /// @notice Per-chain canonical store of managers, co-signers, and thresholds.
     IAuthRegistry public authRegistry;
@@ -148,6 +160,23 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
         isInitialized = true;
     }
 
+    /// @notice Sets the trusted CCTP relay entry point and the gas-refund overhead allowance applied
+    ///         to bundles entered through it.
+    /// @dev Gated by the AdminVault `OWNER_ROLE` — the production governance authority — not by
+    ///      `CONFIG_SETTER` (deploy-time only). Kept out of `initializeConfig` so the relay entry can
+    ///      be retargeted or its allowance recalibrated without redeploying the module and
+    ///      re-enabling it on every Safe. Pass `address(0)` to disable the allowance.
+    /// @param _cctpBundleReceiver Trusted CCTP relay contract whose calls qualify for the allowance.
+    /// @param _cctpRelayOverhead Fixed gas allowance added to refunds entered via the relay.
+    function setCctpRelayRefundConfig(
+        address _cctpBundleReceiver,
+        uint256 _cctpRelayOverhead
+    ) external onlyInitialized {
+        require(ADMIN_VAULT.hasRole(ADMIN_VAULT.OWNER_ROLE(), msg.sender), "Unauthorized");
+        cctpBundleReceiver = _cctpBundleReceiver;
+        cctpRelayOverhead = _cctpRelayOverhead;
+    }
+
     /// @notice ERC-165 interface support check.
     /// @param interfaceId The interface identifier to query
     /// @return True if this contract supports the given interface
@@ -159,7 +188,7 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
 
     /// @notice Executes a validated bundle for the current chain and nonce.
     ///         Flow: recover signers → deploy Safe if requested → classify signers → verify
-    ///         thresholds → apply auth update → execute sequence.
+    ///         thresholds → execute sequence.
     ///         Safe deployment is resolved before signer classification so that the classification
     ///         loop always operates on a deployed Safe with a real owner list and registry state.
     /// @dev `nonReentrant` blocks any re-entry into bundle execution within the same transaction.
@@ -169,7 +198,7 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     ///      top-level transaction. A manager-controlled action calling back into the module is
     ///      therefore the only re-entry path, and it is rejected.
     /// @param _safeAddr The Safe address to execute on
-    /// @param _bundle The bundle containing sequences for multiple chains and optional auth update
+    /// @param _bundle The bundle containing sequences for multiple chains
     /// @param _signatures Packed EIP-712 signatures sorted by signer address ascending.
     ///        Each signature is 65 bytes (r[32] || s[32] || v[1]).
     function executeBundle(
@@ -194,8 +223,6 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
         (bool hasOwner, bool hasManager, address managerAddr, uint256 coSignCount) = _classifySigners(_safeAddr, signers);
 
         _verifyThresholds(_safeAddr, hasOwner, hasManager, coSignCount);
-
-        _applyAuthUpdate(_safeAddr, _bundle.authUpdate, hasOwner, hasManager, signers[0]);
 
         (bool hasSequence, ITyped.ChainSequence memory targetSeq) = _tryFindChainSequence(
             _bundle.sequences, block.chainid, expectedSequenceNonce
@@ -313,7 +340,9 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     /// @param _safeAddr The deployed Safe whose owner list is used for classification
     /// @param _signers Recovered signer addresses (from _recoverSigners)
     /// @return hasOwner True if at least one signer is a Safe owner
-    /// @return hasManager True if at least one signer is a registered manager
+    /// @return hasManager True if exactly one signer is a registered manager. At most one manager is
+    ///         permitted per bundle — a second manager signature reverts with
+    ///         EIP712TypedDataSafeModule_MultipleManagers.
     /// @return managerAddr The manager address (address(0) if no manager)
     /// @return coSignCount Number of co-signer signatures (does NOT include owner or manager)
     function _classifySigners(
@@ -388,41 +417,6 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
                 revert Errors.EIP712TypedDataSafeModule_ActionTypeNotAllowedForManager(_manager, actionType);
             }
         }
-    }
-
-    /// @notice Applies an auth config update from the bundle if present (newVersion != 0).
-    ///         Only Owner-signed bundles (no manager) may carry auth updates.
-    ///         Intentionally runs BEFORE the chain-sequence check and BEFORE sequence execution so that:
-    ///         (a) an Owner bundle can propagate auth to any chain it's submitted on (cross-chain auth),
-    ///         (b) any `CCTPBridgeSend(propagateAuth=true)` in the sequence emits the post-update snapshot.
-    ///      Replay safety: version-monotonic + expiry + per-Safe nonce (on sequence execution).
-    /// @param _safeAddr The Safe to update auth config for
-    /// @param _update The auth update payload (newVersion == 0 means no-op)
-    /// @param _hasOwner Whether an owner signature is present
-    /// @param _hasManager Whether a manager signature is present
-    /// @param _firstSigner The lowest-address signer (signers are sorted ascending). Emitted in the
-    ///        revert for diagnostic correlation — it is NOT necessarily the signer who "caused" the
-    ///        failure (e.g. a cosigner could be the lowest address).
-    function _applyAuthUpdate(
-        address _safeAddr,
-        ITyped.AuthUpdate calldata _update,
-        bool _hasOwner,
-        bool _hasManager,
-        address _firstSigner
-    ) internal {
-        if (_update.newVersion == 0) return;
-
-        if (!_hasOwner || _hasManager) {
-            revert Errors.EIP712TypedDataSafeModule_OnlyOwnerCanUpdateAuth(_firstSigner);
-        }
-        authRegistry.setAuthConfig(
-            _safeAddr,
-            _update.newVersion,
-            _update.newManagers,
-            _update.newCoSigners,
-            _update.managerCoSignThreshold,
-            _update.managerRestrictions
-        );
     }
 
     /// @notice Executes the chain sequence for the current chain.
@@ -572,7 +566,9 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
     /// @notice Calculates and executes a gas refund in USDC using the gas price adaptor's rate.
     /// @param safe The Safe that owns the USDC used for the refund
     /// @param maxRefundAmount Bundle-level cap on the refund amount (0 = no cap)
-    /// @param refundRecipient 0 = refund to tx.origin, non-zero = refund to FEE_RECIPIENT
+    /// @param refundRecipient 0 = refund to tx.origin, 1 = refund to FEE_RECIPIENT. Only 0 or 1 are
+    ///        valid; any other value is rejected upstream in _validateSequenceActionsAndDetectRefund
+    ///        when a fee action is present.
     /// @param gasStart The gasleft() snapshot captured at the start of bundle execution
     function _executeGasRefund(
         address safe,
@@ -591,7 +587,14 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
         (uint256 ratePerGas, uint256 fixedFee) = _getRefundRate();
 
         if (ratePerGas > 0) {
-            uint256 gasUsed = gasStart > gasleft() ? (gasStart - gasleft() + gasRefundOverhead) : 0;
+            uint256 overhead = gasRefundOverhead;
+            // The CCTP relay path spends gas on message validation, Circle's receiveMessage mint, and
+            // module discovery before gasStart is captured; add the configured allowance so the
+            // relayer is refunded for that out-of-band work. maxRefundAmount still caps the payout.
+            if (cctpBundleReceiver != address(0) && msg.sender == cctpBundleReceiver) {
+                overhead += cctpRelayOverhead;
+            }
+            uint256 gasUsed = gasStart > gasleft() ? (gasStart - gasleft() + overhead) : 0;
 
             if (gasUsed > 0) {
                 refundAmount = (gasUsed * ratePerGas) / 1e18 + fixedFee;
@@ -651,7 +654,9 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
 
     /// @notice Validates each action in a sequence against its on-chain definition and detects gas refund actions.
     /// @param _sequence The sequence whose actions are being validated
-    /// @param _refundRecipient Non-zero if the bundle expects a gas refund (used to detect refund actions)
+    /// @param _refundRecipient Selects the gas-refund recipient: 0 = tx.origin, 1 = FEE_RECIPIENT. When a
+    ///        fee action is present any value other than 0 or 1 reverts with
+    ///        EIP712TypedDataSafeModule_InvalidRefundRecipient.
     /// @return actionIds The validated action ID selectors
     /// @return hasRefundAction True if one of the actions is a gas refund action
     function _validateSequenceActionsAndDetectRefund(ITyped.Sequence memory _sequence, uint8 _refundRecipient)
@@ -745,8 +750,6 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
             _deploySafeForEstimation(_safeAddr, msg.sender);
         }
 
-        _applySimulationAuthUpdate(_safeAddr, _bundle.authUpdate);
-
         (bytes4[] memory actionIds, bool hasRefundAction) = _validateSequenceActionsAndDetectRefund(
             targetSequence.sequence,
             targetSequence.refundRecipient
@@ -788,24 +791,6 @@ contract EIP712TypedDataSafeModule is ERC165, ReentrancyGuard {
                 revert Errors.EIP712TypedDataSafeModule_SafeDeploymentFailed();
             }
         }
-    }
-
-    /// @notice Applies an auth update during gas estimation (no owner/manager gating).
-    /// @param _safeAddr The Safe to update auth config for
-    /// @param _update The auth update payload (newVersion == 0 means no-op)
-    function _applySimulationAuthUpdate(
-        address _safeAddr,
-        ITyped.AuthUpdate calldata _update
-    ) internal {
-        if (_update.newVersion == 0) return;
-        authRegistry.setAuthConfig(
-            _safeAddr,
-            _update.newVersion,
-            _update.newManagers,
-            _update.newCoSigners,
-            _update.managerCoSignThreshold,
-            _update.managerRestrictions
-        );
     }
 
     /// @notice Rejects direct ETH transfers to prevent accidental locking.

--- a/contracts/docs/AUTH_SYSTEM_OVERVIEW.md
+++ b/contracts/docs/AUTH_SYSTEM_OVERVIEW.md
@@ -12,7 +12,7 @@ deployed the Safe. They hold the Safe's signing key and have ultimate authority:
 
 - Full control over auth configuration (managers, co-signers, thresholds)
 - Can execute any sequence of actions without co-signing requirements
-- Can update auth config on the current chain and propagate it cross-chain
+- Signs one chain-agnostic auth config that any relayer can apply on any chain
 - Can withdraw funds via the EmergencyWithdrawModule at any time
 
 The owner does **not** perform day-to-day DeFi operations. Their role is setup,
@@ -27,7 +27,7 @@ by Brava on behalf of the custodian.
 - Executes sequences (supply, withdraw, swap, bridge, etc.) via signed bundles
 - May require co-signer approval depending on the threshold set by the owner
 - Can be scoped to specific action types (e.g. only supply/withdraw, not swaps)
-- **Cannot** modify auth config — only the owner can add/remove managers
+- **Cannot** modify auth config — only an owner-signed AuthBundle can
 - At most one manager signature per bundle (enforced by the module)
 
 ### Co-signer
@@ -50,25 +50,28 @@ The owner (or the Brava relayer on behalf of the owner) deploys a Safe via
 
 ### 2. Auth Configuration
 
-The owner signs a bundle carrying an `AuthUpdate` to register:
+The owner signs an EIP-712 `AuthBundle` — separate from execution bundles —
+carrying a complete auth config snapshot:
 
 - **Managers** — addresses that will execute day-to-day operations
 - **Co-signers** — addresses required to co-approve manager bundles
 - **Co-sign threshold** — how many co-signers a manager bundle needs
 - **Manager restrictions** (optional) — per-manager action type limits
 
-This auth config is stored in the `AuthRegistry`, not in the module itself.
-The registry is a separate contract so that auth state survives module upgrades.
+Any relayer submits the signed bundle to `AuthRegistry.applyAuthBundle` — the
+registry's **single write path**. The signature, not the caller, carries the
+authority. Auth state is stored in the `AuthRegistry`, not in the module, so it
+survives module upgrades.
 
-The owner can propagate the same auth config to other chains in two ways:
+Cross-chain propagation is by construction: the AuthBundle's EIP-712 domain
+binds to the **Safe** (chainId fixed at 1), not to any chain or contract
+deployment, so the same signed payload is relayable on every chain — including
+chains added after signing. Auth config never travels over a bridge; CCTP
+messages carry no auth data.
 
-1. **Same bundle, multiple chains** — the bundle contains chain sequences for
-   each target chain. When submitted on each chain, the auth update applies
-   before any sequence executes.
-2. **CCTP propagation** — a `CCTPBridgeSend` action with `propagateAuth=true`
-   encodes the current auth snapshot into the CCTP hook data. The destination
-   chain's `AuthRegistry` receives the Circle-attested message and applies the
-   snapshot, optionally executing a bundle in the same transaction.
+If the Safe is not yet deployed on a chain, ownership is proven by matching the
+signer's deterministic CREATE2 Safe address, so auth config can land before the
+Safe lazily deploys during its first bundle execution.
 
 ### 3. Day-to-Day Operations
 
@@ -86,20 +89,14 @@ The module validates:
 5. **Action validity** — each action ID must exist in AdminVault and match the
    declared `protocolName` and `actionType`
 6. **Nonce** — per-Safe monotonic nonce prevents replay
+7. **Reentrancy** — `executeBundle` is `nonReentrant`; a bundle cannot be
+   re-entered mid-sequence within the same transaction
 
 ### 4. Auth Updates
 
-Only the **owner** can update auth config. The update is carried inside the
-bundle's `authUpdate` field with a monotonically increasing version number.
-Auth updates apply **before** sequence execution so that:
-
-- A `CCTPBridgeSend(propagateAuth=true)` in the sequence emits the post-update
-  snapshot
-- The update applies on every chain the bundle is submitted to, not just the
-  chain with a sequence
-
-A manager **cannot** carry an auth update — the module reverts if a manager
-signature is present and `authUpdate.newVersion != 0`.
+Only the **owner** can update auth config, by signing a new `AuthBundle` with a
+higher version number and having it relayed to `applyAuthBundle`. Execution
+bundles cannot carry auth updates — the two signing flows are fully separate.
 
 ### 5. Manager Restrictions
 
@@ -124,12 +121,11 @@ the bundle on each target chain. The module picks the sequence matching
 `block.chainid` and the Safe's current nonce.
 
 For fund movement between chains, the CCTP bridge actions handle Circle's
-cross-chain transfer protocol. The `relayCCTPAndExecute` path on AuthRegistry
-combines three operations into a single attested message:
-
-1. Mint USDC on the destination chain
-2. Apply an auth config snapshot (if present in hook data)
-3. Execute a bundle through the destination Safe's module
+cross-chain transfer protocol. The destination entry point is
+`CCTPBundleReceiver`: a permissionless relay mints the attested USDC to the
+Safe and best-effort executes a separately-signed bundle. CCTP messages carry
+**no** auth data — auth config is applied per-chain through the registry's
+`applyAuthBundle` path only.
 
 ### 7. Emergency Recovery
 
@@ -144,25 +140,29 @@ path is disabled, the Safe owner can still:
 The module is stateless, has no admin, and has no dependency on any
 Brava-controlled contract. Both the caller and recipient must be Safe owners.
 
-## Auth Registry: Three Write Paths
+## Auth Registry: Single Write Path
 
-The AuthRegistry has three ways to receive an auth config update, all sharing
-the same validation and application logic:
+The AuthRegistry has exactly one way to receive an auth config update:
 
 | Path | Trigger | Trust Source | Bundle Execution |
 |------|---------|-------------|-----------------|
-| `setAuthConfig` | Module call after owner bundle verification | Module must be enabled on the Safe | N/A (already in module flow) |
-| `receiveCCTPAuthUpdate` | Permissionless relay of Circle attestation | CCTP message with burn/mint/hook triple-check | No |
-| `relayCCTPAndExecute` | Permissionless relay of Circle attestation | Same as above, plus best-effort bundle forward | Yes (best-effort) |
+| `applyAuthBundle` | Permissionless relay of an Owner-signed AuthBundle | EIP-712 signature by a Safe owner (or, pre-deployment, the CREATE2-derived owner) | No (auth only) |
 
-All three paths enforce:
+Every application enforces:
 
 - Version must be monotonically increasing (stale versions revert)
+- Version cannot jump forward by more than `MAX_VERSION_INCREASE` (10) — bounds
+  version-space exhaustion while letting a chain skip missed versions
 - Same version with identical config is idempotent (no-op)
 - Same version with different config is a conflict (reverts)
 - Max 10 managers, max 10 co-signers per Safe
 - No zero addresses, no address in both manager and co-signer sets
-- Threshold cannot exceed co-signer count
+- Threshold cannot exceed co-signer count. A threshold of **0 with co-signers
+  present is permitted**: it registers a dormant co-signer set for staged
+  onboarding (the co-signer can be exercised in simulation without gating live
+  execution); the threshold is raised in a later update
+- Bundle expiry (`expiry`) bounds how long an unrelayed signed config stays
+  submittable
 
 ## Signer Classification Priority
 
@@ -187,7 +187,8 @@ Auth config versions are per-Safe monotonic counters:
 
 - **Version 0** is reserved (the "uninitialized" sentinel)
 - **First config** must use version >= 1
-- Each subsequent update must use a version strictly greater than the current
+- Each subsequent update must use a version strictly greater than the current,
+  at most `MAX_VERSION_INCREASE` (10) ahead
 - Submitting the same version with the same config is a no-op (idempotent)
 - Submitting the same version with different config reverts (conflict)
 

--- a/contracts/docs/CCTP_RECEIVE_FLOW_IMPLEMENTATION.md
+++ b/contracts/docs/CCTP_RECEIVE_FLOW_IMPLEMENTATION.md
@@ -51,14 +51,12 @@ curl "https://iris-api.circle.com/v2/messages/{sourceDomain}?transactionHash={tx
   is authorized by Circle to successfully call `receiveMessage` for the message.
 - `hookData` is embedded in the CCTP V2 message. Circle does not call any hook;
   the destination relayer interprets and acts on it.
-- Brava uses two `hookData` envelopes selected by the leading version byte:
-  - **Bundle envelope (no version byte)** — `[20-byte target][raw calldata]`.
-    Used by the non-auth path on `CCTPBundleReceiver`. The target is informational
-    only in the new flow — the receiver discovers the destination Safe's Brava
-    module via ERC-165 (see "Module Discovery" below).
-  - **Auth envelope (`hookVersion = 1`)** —
-    `abi.encode(uint8(1), abi.encode(safe, version, managers[], coSigners[], ownerCoSignThreshold, managerCoSignThreshold))`.
-    Decoded by `AuthRegistry` to apply a full auth config snapshot.
+- Brava uses a single `hookData` envelope:
+  - **Bundle envelope** — `[20-byte target][raw calldata]`. Used by
+    `CCTPBundleReceiver`. The target is informational only — the receiver discovers
+    the destination Safe's Brava module via ERC-165 (see "Module Discovery" below).
+  - CCTP messages carry **no** auth data: a relay only mints USDC and best-effort
+    executes a separately-signed bundle. Auth config is never propagated over CCTP.
 - Contract addresses (CCTP v2) are chain-constant:
   - `MessageTransmitter`: `0x81D40F21F12A8F0E3252Bccb954D722d4c464B64`
   - `TokenMessenger`: `0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d`
@@ -66,12 +64,9 @@ curl "https://iris-api.circle.com/v2/messages/{sourceDomain}?transactionHash={tx
 
 ## Brava Integration
 
-There are two destination entry points, picked at *send* time via
-`destinationCaller`:
+There is a single destination entry point, `CCTPBundleReceiver`:
 
-### Non-auth path — `CCTPBundleReceiver`
-
-- Source: `CCTPBridgeSend` with `propagateAuth = false`. Caller supplies
+- Source: `CCTPBridgeSend`. Caller supplies
   `destinationCaller = address(CCTPBundleReceiver)`.
 - Destination: anyone calls `CCTPBundleReceiver.relay(message, attestation)`
   (mint only) or `CCTPBundleReceiver.relayWithBundle(message, attestation, safe,
@@ -79,32 +74,18 @@ There are two destination entry points, picked at *send* time via
   module discovered via ERC-165 on the Safe).
 - Permissionless. Bundle execution is best-effort and decoupled from the mint
   outcome only when the bundle is supplied separately.
+- CCTP carries no auth data. Auth config changes are applied per-chain through
+  `AuthRegistry` directly (signed `AuthBundle`), never propagated over the bridge.
+- Both entry points emit the `CCTP_BUNDLE_RECEIVE` Logger event (`LogType` 15) on
+  every successful mint — `relay()` and an empty-bundle `relayWithBundle()`
+  included — so the destination mint leg is always observable to the indexer, not
+  only when a bundle runs. The event carries `(safe, amount, bundleSuccess, nonce,
+  sourceDomain)`; `bundleSuccess` is `true` when no bundle ran, else the bundle's
+  best-effort outcome. The `nonce` is the full CCTP `bytes32`.
 
-### Auth-aware path — `AuthRegistry`
+### Module Discovery
 
-- Source: `CCTPBridgeSend` with `propagateAuth = true`. The action ignores
-  caller-supplied `destinationCaller` and forces it to
-  `address(AUTH_REGISTRY)` (CreateX-derived constant — same address on every
-  chain). It reads `(version, managers[], coSigners[], ownerCoSignThreshold,
-  managerCoSignThreshold)` from the source-chain registry for the Safe under
-  delegatecall and encodes the auth envelope into `hookData`.
-- Destination: anyone calls
-  `AuthRegistry.relayCCTPAndExecute(message, attestation, safe, bundle, signature)`,
-  which:
-  1. Validates `_safe` matches the CCTP message's `mintRecipient`.
-  2. Calls `MessageTransmitter.receiveMessage` (mints USDC; whole tx reverts on
-     failure).
-  3. If `hookData` carries `hookVersion = 1`, enforces the triple-check
-     (`burnSender == hookData.safe == mintRecipient`) and applies the
-     snapshot.
-  4. Discovers the Safe's Brava module via `BravaModuleLookup` and best-effort
-     forwards `executeBundle(safe, bundle, signature)`.
-- For auth-only updates without a bundle, callers can use
-  `AuthRegistry.receiveCCTPAuthUpdate(message, attestation)`.
-
-### Module Discovery (shared)
-
-Both relay contracts use `BravaModuleLookup.findEnabledBravaModule(ISafe)`:
+`CCTPBundleReceiver` uses `BravaModuleLookup.findEnabledBravaModule(ISafe)`:
 
 - Iterates the first page (capped at 10) of `getModulesPaginated`.
 - Calls `supportsInterface(type(IBravaSafeModule).interfaceId)` on each, with
@@ -114,23 +95,18 @@ Both relay contracts use `BravaModuleLookup.findEnabledBravaModule(ISafe)`:
 
 `EIP712TypedDataSafeModule` inherits OpenZeppelin's `ERC165` and registers the
 `IBravaSafeModule` marker — so module upgrades that keep the `executeBundle`
-shape are automatically picked up by the next CCTP relay through either entry
-point. No relay contract holds a module address.
+shape are automatically picked up by the next CCTP relay. The relay contract
+holds no module address.
 
 ## Considerations
 
 - Each message can be processed once; handle already-processed cases gracefully.
-- Both relay entry points are permissionless — anyone willing to pay gas can
-  unstick funds and propagate auth/bundle execution.
-- Bundle execution on the registry path is best-effort: a failed signature does
-  not revert the auth snapshot or the mint. Mint failure does revert.
-- Auth messages are anchored by the triple-check
-  (`burnSender == hookData.safe == mintRecipient`), enforced inside the
-  registry. `burnSender` is `BurnMessage.messageSender` — the source-chain
-  burner — at full-message offset 248, **not** the outer header `sender` at
-  offset 44 which holds Circle's `TokenMessengerV2`. See
-  `packages/contracts/docs/CCTP_V2_MESSAGE_LAYOUT.md` for the canonical byte
-  layout. The CreateX-constant `destinationCaller` removes a foot-gun where a
-  caller could route an auth message to the wrong contract and strand the
-  nonce.
+- The relay entry point is permissionless — anyone willing to pay gas can unstick
+  funds and trigger bundle execution.
+- Bundle execution is best-effort: a failed signature does not revert the mint.
+  Mint failure does revert.
+- See `packages/contracts/docs/CCTP_V2_MESSAGE_LAYOUT.md` for the canonical byte
+  layout (`burnSender` is `BurnMessage.messageSender` at full-message offset 248,
+  **not** the outer header `sender` at offset 44 which holds Circle's
+  `TokenMessengerV2`).
 - Reference: Circle's hook wrapper guidance (see `CCTPHookWrapper.sol`).

--- a/contracts/docs/TYPED_DATA_MODULE.md
+++ b/contracts/docs/TYPED_DATA_MODULE.md
@@ -1,19 +1,28 @@
 # EIP-712 Typed Data Module
 
 The `EIP712TypedDataSafeModule` executes multi-signed bundles with chain-specific
-sequences. It verifies signer authority via the AuthRegistry, handles optional
-Safe deployment, enforces manager restrictions, and can process USDC gas refunds.
+sequences. It verifies signer authority against the Safe's owner list and the
+`AuthRegistry`, handles optional Safe deployment, enforces manager restrictions,
+and can process USDC gas refunds.
+
+Auth configuration (managers, co-signers, thresholds) is **not** carried in
+execution bundles. It is written exclusively through the `AuthRegistry`'s own
+Owner-signed `AuthBundle` path (`applyAuthBundle`) — see
+`AUTH_SYSTEM_OVERVIEW.md`. The module only reads from the registry.
 
 ## Core Behavior
 
 - Domain separator uses `chainId: 1` and the target Safe as the verifying
-  contract.
+  contract, so one signature is valid on every chain.
 - Per-Safe nonces are stored on the module and incremented on success.
 - A sequence is selected by `block.chainid` and the expected nonce.
 - Actions are validated against `AdminVault` and the action's `protocolName()`
   and `actionType()`.
 - Sequence execution happens via the Safe (module call →
   `execTransactionFromModule` → `delegatecall` into `SequenceExecutor`).
+- `executeBundle` is `nonReentrant`: re-entering bundle execution within the
+  same transaction reverts. Legitimate cross-Safe concurrency happens in
+  separate transactions and is unaffected.
 - If `enableGasRefund=true`, the sequence must include a refund action
   (`ActionType.FEE_ACTION`). If `enableGasRefund=false`, it must not. The
   module enforces both directions.
@@ -40,30 +49,16 @@ struct ChainSequence {
     Sequence sequence;
 }
 
-struct ManagerRestriction {
-    address manager;
-    uint8[] allowedActionTypes; // bitmap derived on-chain
-}
-
-struct AuthUpdate {
-    uint256 newVersion;           // 0 = no update
-    address[] newManagers;
-    address[] newCoSigners;
-    uint256 managerCoSignThreshold;
-    ManagerRestriction[] managerRestrictions;
-}
-
 struct Bundle {
     uint256 expiry;
     ChainSequence[] sequences;
-    AuthUpdate authUpdate;
 }
 ```
 
 ## Execution Flow
 
 ```
-executeBundle(safe, bundle, signatures)
+executeBundle(safe, bundle, signatures)   [nonReentrant]
   │
   ├─ 1. Reject expired bundles
   ├─ 2. Compute EIP-712 digest
@@ -71,13 +66,13 @@ executeBundle(safe, bundle, signatures)
   ├─ 4. Deploy Safe if target sequence has deploySafe=true and Safe doesn't exist
   ├─ 5. Classify each signer: Owner > CoSigner > Manager > Reject
   ├─ 6. Verify thresholds (owner or manager required; manager needs co-signatures)
-  ├─ 7. Apply auth update if present (owner-only, runs before sequence execution)
-  ├─ 8. Find chain sequence matching block.chainid and expected nonce
-  ├─ 9. Enforce manager restrictions (if manager-signed, no owner)
+  ├─ 7. Find chain sequence matching block.chainid and expected nonce
+  ├─ 8. Enforce manager restrictions (if manager-signed, no owner)
+  ├─ 9. Log BUNDLE_AUTHORISED (bundle hash, authorising principal, co-signers)
   ├─ 10. Validate action definitions against AdminVault
   ├─ 11. Execute sequence through Safe via delegatecall
   ├─ 12. Process gas refund if enabled
-  └─ 13. Log sequence completion
+  └─ 13. Log SEQUENCE_COMPLETE (consumed nonce + chain-independent bundle hash)
 ```
 
 ### Signature Format
@@ -101,17 +96,6 @@ At most one manager is allowed per bundle. Owner classification takes priority,
 so an address that is both a Safe owner and a registered manager/co-signer will
 always count as an Owner.
 
-### Auth Updates
-
-An `AuthUpdate` with `newVersion != 0` triggers a full auth config replacement
-on the AuthRegistry. Only owner-signed bundles (no manager) may carry updates.
-The update applies before sequence execution so that CCTP propagation actions in
-the sequence emit the post-update snapshot.
-
-Auth updates apply on **every chain** the bundle is submitted to, not just the
-chain with a matching sequence. This is by design — auth state is global per
-Safe and cross-chain propagation relies on this.
-
 ### Manager Restrictions
 
 When a bundle is signed by a manager (and no owner), the module checks each
@@ -132,6 +116,20 @@ function getBundleHash(address safe, Bundle calldata bundle) external view retur
 function getRawBundleHash(Bundle calldata bundle) external pure returns (bytes32);
 ```
 
+## Execution Audit Trail
+
+Two Logger events tie every executed leg back to the signed bundle and its
+signers:
+
+- **`BUNDLE_AUTHORISED`** — emitted once per executed leg, carrying the
+  chain-independent bundle struct hash, the authorising principal (owner or
+  manager), and the co-signer addresses. Owner-vs-manager is resolved off-chain
+  from Safe/registry state.
+- **`SEQUENCE_COMPLETE`** — emitted after the sequence executes, carrying the
+  consumed nonce and the same bundle hash, so off-chain indexers can link all
+  legs of one signed bundle across chains (including both sides of a bridge
+  pair).
+
 ## Gas Refunds
 
 - Sequences implement refunds via a dedicated action placed in the sequence and
@@ -140,8 +138,14 @@ function getRawBundleHash(Bundle calldata bundle) external pure returns (bytes32
   - `enableGasRefund=true` → refund action required
   - `enableGasRefund=false` → refund action forbidden
 - USDC is used for refund payments via a gas price adaptor oracle.
-- Recipient is tx.origin (0) or the module's fee recipient (1).
+- Recipient is tx.origin (0) or the module's fee recipient (1); any other
+  value reverts when a fee action is present.
 - `maxRefundAmount` caps the refund (0 = no cap).
+- Bundles entered through the trusted `cctpBundleReceiver` get a configurable
+  `cctpRelayOverhead` gas allowance added, covering relay work (CCTP message
+  validation, Circle's mint, module discovery) spent before the module's gas
+  snapshot. Set via `setCctpRelayRefundConfig` (AdminVault owner-gated); the
+  payout is still capped by `maxRefundAmount`.
 - Any USDC remainder on the module is returned to the Safe after refund.
 
 ## Gas Estimation

--- a/contracts/interfaces/IActionBase.sol
+++ b/contracts/interfaces/IActionBase.sol
@@ -19,7 +19,8 @@ interface IActionBase {
         COVER_ACTION,
         FEE_ACTION,
         TRANSFER_ACTION,
-        CUSTOM_ACTION
+        CUSTOM_ACTION,
+        UPGRADE_ACTION
     }
 
     /// @notice Enum representing different types of logs.
@@ -40,8 +41,6 @@ interface IActionBase {
         CCTP_BRIDGE_SEND,
         GAS_REFUND_RESERVATION,
         SEQUENCE_COMPLETE,
-        CCTP_BUNDLE_RECEIVE,
-        CCTP_BRIDGE_SEND_WITH_AUTH,
-        CCTP_RELAY_AND_EXECUTE
+        CCTP_BUNDLE_RECEIVE
     }
 }

--- a/contracts/interfaces/IActionBase.sol
+++ b/contracts/interfaces/IActionBase.sol
@@ -41,6 +41,7 @@ interface IActionBase {
         CCTP_BRIDGE_SEND,
         GAS_REFUND_RESERVATION,
         SEQUENCE_COMPLETE,
-        CCTP_BUNDLE_RECEIVE
+        CCTP_BUNDLE_RECEIVE,
+        BUNDLE_AUTHORISED
     }
 }

--- a/contracts/interfaces/IAuthRegistry.sol
+++ b/contracts/interfaces/IAuthRegistry.sol
@@ -1,51 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.28;
 
-import {IEip712TypedDataSafeModule as ITyped} from "./IEip712TypedDataSafeModule.sol";
-
 /// @title IAuthRegistry
 /// @notice Interface for AuthRegistry — the per-chain canonical store of authorised managers,
-///         co-signers, and co-signing thresholds per Safe.
+///         co-signers, and co-signing thresholds per Safe. Auth config is written exclusively via
+///         Owner-signed EIP-712 `AuthBundle`s verified by the registry itself.
 /// @notice State changes are logged via the shared Logger (logId 209). No events are declared on this interface.
 interface IAuthRegistry {
-    /// @notice Snapshot-replace the full auth config for a Safe at a new version.
-    /// @dev Module-only: reverts unless `msg.sender` is currently enabled as a module on `_safe`.
-    function setAuthConfig(
-        address _safe,
-        uint256 _newVersion,
-        address[] calldata _newManagers,
-        address[] calldata _newCoSigners,
-        uint256 _managerCoSignThreshold,
-        ITyped.ManagerRestriction[] calldata _managerRestrictions
-    ) external;
+    /// @notice Per-manager restriction: limits which ActionType values a manager may execute.
+    /// @dev Only restricted managers need entries. A manager absent from managerRestrictions is unrestricted.
+    struct ManagerRestriction {
+        address manager;
+        uint8[] allowedActionTypes;
+    }
 
-    /// @notice Permissionless CCTP relay: copies an auth config snapshot from a source-chain Safe.
-    function receiveCCTPAuthUpdate(
-        bytes calldata _message,
-        bytes calldata _attestation
-    ) external;
+    /// @notice Complete auth config snapshot applied at a monotonically increasing version.
+    /// @dev The Owner signs the full target auth config; the registry handles the atomic state
+    ///      transition with version-monotonic semantics and idempotent equality. The snapshot is
+    ///      chain-agnostic: the same signed payload is valid on every chain (and on chains added
+    ///      later), enabling store-and-relay cross-chain propagation.
+    struct AuthUpdate {
+        uint256 newVersion;
+        address[] newManagers;
+        address[] newCoSigners;
+        uint256 managerCoSignThreshold;
+        ManagerRestriction[] managerRestrictions;
+    }
 
-    /// @notice Permissionless combined CCTP relay: mints USDC, optionally applies an attested
-    ///         auth config snapshot from `hookData`, and best-effort executes a bundle through the
-    ///         destination Safe's currently-enabled Brava module (discovered via ERC-165).
-    /// @dev Bundle failure does NOT revert — funds remain in the Safe and the bundle can be retried.
-    ///      Mint failure DOES revert.
-    ///      IMPORTANT: auth state from hookData is committed regardless of `bundleSuccess`. If a
-    ///      bundle reverts inside the module, the auth update still holds. Callers and indexers
-    ///      should treat `authApplied` and `bundleSuccess` as independent outcomes.
-    /// @return authApplied True if hookData contained a valid auth snapshot that was applied.
-    /// @return bundleSuccess True if the module's executeBundle call succeeded.
-    /// @return bundleReturnData Module return data on success, or revert data on failure.
-    ///         Empty when no module was found (distinguish via event logs or bundleSuccess=false
-    ///         with zero-length returnData).
-    function relayCCTPAndExecute(
-        bytes calldata _message,
-        bytes calldata _attestation,
+    /// @notice Owner-signed EIP-712 payload carrying an auth config snapshot.
+    /// @dev Signed against the chain-agnostic domain (chainId=1, verifyingContract=Safe), so one
+    ///      signature authorises the snapshot on all chains. Expiry is typically far in the future;
+    ///      replay protection comes from the registry's version monotonicity, not the expiry.
+    struct AuthBundle {
+        uint256 expiry;
+        AuthUpdate authUpdate;
+    }
+
+    /// @notice Verifies an Owner-signed AuthBundle and snapshot-replaces the Safe's auth config.
+    /// @dev Permissionless relayer entry: the signature, not the caller, carries the authority.
+    function applyAuthBundle(
         address _safe,
-        address _ownerAddress,
-        ITyped.Bundle calldata _bundle,
-        bytes calldata _signatures
-    ) external returns (bool authApplied, bool bundleSuccess, bytes memory bundleReturnData);
+        AuthBundle calldata _bundle,
+        bytes calldata _signature
+    ) external;
 
     function isManager(address _safe, address _addr) external view returns (bool);
 
@@ -63,12 +60,13 @@ interface IAuthRegistry {
 
     function getManagerActionBitmap(address _safe, address _manager) external view returns (uint256);
 
+    function getDomainSeparator(address _safeAddr) external view returns (bytes32);
+
+    function getAuthBundleHash(address _safeAddr, AuthBundle calldata _bundle) external view returns (bytes32);
+
     // solhint-disable-next-line func-name-mixedcase
     function MAX_MANAGERS_PER_SAFE() external view returns (uint256);
 
     // solhint-disable-next-line func-name-mixedcase
     function MAX_COSIGNERS_PER_SAFE() external view returns (uint256);
-
-    // solhint-disable-next-line func-name-mixedcase
-    function MESSAGE_TRANSMITTER() external view returns (address);
 }

--- a/contracts/interfaces/IBravaSafeModule.sol
+++ b/contracts/interfaces/IBravaSafeModule.sol
@@ -8,7 +8,7 @@ import {IEip712TypedDataSafeModule as ITyped} from "./IEip712TypedDataSafeModule
 ///         on a given Safe. Intentionally minimal — only the bundle execution entry point — so that
 ///         the `interfaceId` stays stable across module upgrades that add features but keep the
 ///         primary entry point shape.
-/// @dev Bridge relay paths (`CCTPBundleReceiver`, `AuthRegistry.relayCCTPAndExecute`) use
+/// @dev The bridge relay path (`CCTPBundleReceiver`) uses
 ///      `BravaModuleLookup` to find the unique enabled module on a Safe that returns true from
 ///      `supportsInterface(type(IBravaSafeModule).interfaceId)`. This decouples relay infrastructure
 ///      from any single module address, so module upgrades require no redeploys downstream.

--- a/contracts/interfaces/ICreateX.sol
+++ b/contracts/interfaces/ICreateX.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.4;
+
+/**
+ * @title CreateX Factory Interface Definition
+ * @author pcaversaccio (https://web.archive.org/web/20230921103111/https://pcaversaccio.com/)
+ * @custom:coauthor Matt Solomon (https://web.archive.org/web/20230921103335/https://mattsolomon.dev/)
+ */
+interface ICreateX {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                            TYPES                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    struct Values {
+        uint256 constructorAmount;
+        uint256 initCallAmount;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           EVENTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    event ContractCreation(address indexed newContract, bytes32 indexed salt);
+    event ContractCreation(address indexed newContract);
+    event Create3ProxyContractCreation(address indexed newContract, bytes32 indexed salt);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CUSTOM ERRORS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    error FailedContractCreation(address emitter);
+    error FailedContractInitialisation(address emitter, bytes revertData);
+    error InvalidSalt(address emitter);
+    error InvalidNonceValue(address emitter);
+    error FailedEtherTransfer(address emitter, bytes revertData);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreateAndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreateAndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values
+    ) external payable returns (address newContract);
+
+    function deployCreateClone(address implementation, bytes memory data) external payable returns (address proxy);
+
+    function computeCreateAddress(address deployer, uint256 nonce) external view returns (address computedAddress);
+
+    function computeCreateAddress(uint256 nonce) external view returns (address computedAddress);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE2                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate2(bytes32 salt, bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate2(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate2AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate2AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values
+    ) external payable returns (address newContract);
+
+    function deployCreate2AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate2AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values
+    ) external payable returns (address newContract);
+
+    function deployCreate2Clone(
+        bytes32 salt,
+        address implementation,
+        bytes memory data
+    ) external payable returns (address proxy);
+
+    function deployCreate2Clone(address implementation, bytes memory data) external payable returns (address proxy);
+
+    function computeCreate2Address(
+        bytes32 salt,
+        bytes32 initCodeHash,
+        address deployer
+    ) external pure returns (address computedAddress);
+
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address computedAddress);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE3                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate3(bytes32 salt, bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate3(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate3AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate3AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values
+    ) external payable returns (address newContract);
+
+    function deployCreate3AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate3AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values
+    ) external payable returns (address newContract);
+
+    function computeCreate3Address(bytes32 salt, address deployer) external pure returns (address computedAddress);
+
+    function computeCreate3Address(bytes32 salt) external view returns (address computedAddress);
+}

--- a/contracts/interfaces/IEip712TypedDataSafeModule.sol
+++ b/contracts/interfaces/IEip712TypedDataSafeModule.sol
@@ -31,40 +31,15 @@ interface IEip712TypedDataSafeModule {
         Sequence sequence;
     }
 
-    /// @notice Per-manager restriction: limits which ActionType values a manager may execute.
-    /// @dev Only restricted managers need entries. A manager absent from managerRestrictions is unrestricted.
-    struct ManagerRestriction {
-        address manager;
-        uint8[] allowedActionTypes;
-    }
-
-    /// @notice Atomic auth config update applied via the bundle.
-    /// @dev `newVersion == 0` is the no-update sentinel: all other fields are ignored.
-    ///      Any non-zero `newVersion` triggers a snapshot replacement on the AuthRegistry,
-    ///      which enforces version-monotonic semantics with idempotent equality.
-    ///      Owner signs the full target auth config; the registry handles the atomic state transition.
-    ///      Auth updates are NOT scoped to the bundle's chain sequences — the update applies on
-    ///      EVERY chain the bundle is submitted to. This is by design: auth state is global per Safe,
-    ///      and cross-chain propagation relies on the update being applied regardless of which chain's
-    ///      sequence is executed.
-    struct AuthUpdate {
-        uint256 newVersion;
-        address[] newManagers;
-        address[] newCoSigners;
-        uint256 managerCoSignThreshold;
-        ManagerRestriction[] managerRestrictions;
-    }
-
-    /// @notice Bundle structure containing multiple chain sequences and an optional auth config update
+    /// @notice Bundle structure containing sequences for multiple chains
     struct Bundle {
         uint256 expiry;
         ChainSequence[] sequences;
-        AuthUpdate authUpdate;
     }
 
     /// @notice Executes a validated bundle for the current chain and nonce
     /// @param _safeAddr The Safe address to execute on
-    /// @param _bundle The bundle containing sequences for multiple chains and an optional auth update
+    /// @param _bundle The bundle containing sequences for multiple chains
     /// @param _signatures Packed EIP-712 signatures sorted by signer address ascending
     function executeBundle(
         address _safeAddr,

--- a/contracts/interfaces/ILogger.sol
+++ b/contracts/interfaces/ILogger.sol
@@ -5,7 +5,7 @@ import {IActionBase} from "./IActionBase.sol";
 
 interface ILogger {
     event ActionEvent(address caller, IActionBase.LogType logId, bytes data);
-    event AdminVaultEvent(uint256 logId, bytes data);
+    event AdminVaultEvent(address caller, uint256 logId, bytes data);
 
     function logActionEvent(IActionBase.LogType _logType, bytes memory _data) external;
     function logAdminVaultEvent(uint256 _logId, bytes memory _data) external;

--- a/contracts/interfaces/IMessageTransmitterV2.sol
+++ b/contracts/interfaces/IMessageTransmitterV2.sol
@@ -9,4 +9,10 @@ interface IMessageTransmitterV2 {
     /// @param attestation Circle attestation proving the message was finalized.
     /// @return success True when the transmitter accepts and consumes the message.
     function receiveMessage(bytes calldata message, bytes calldata attestation) external returns (bool);
+
+    /// @notice Replay-protection map: 0 when the nonce is unconsumed, 1 once a message has been
+    ///         received for it. Keyed by the CCTP V2 message nonce (bytes32 at message offset 12).
+    /// @param nonce CCTP V2 message nonce.
+    /// @return status 0 = unused, 1 = used.
+    function usedNonces(bytes32 nonce) external view returns (uint256);
 }

--- a/contracts/libraries/BravaModuleLookup.sol
+++ b/contracts/libraries/BravaModuleLookup.sol
@@ -9,8 +9,8 @@ import {ISafe} from "../interfaces/safe/ISafe.sol";
 
 /// @title BravaModuleLookup
 /// @notice Discovers the unique Brava module currently enabled on a Safe by ERC-165 introspection.
-///         Used by bridge relays (`CCTPBundleReceiver`, `AuthRegistry.relayCCTPAndExecute`) so
-///         they never hold a module address and survive module upgrades unchanged.
+///         Used by the bridge relay (`CCTPBundleReceiver`) so it never holds a module address and
+///         survives module upgrades unchanged.
 /// @dev Iterates a single page (`MAX_MODULES_SCANNED`) of `getModulesPaginated` starting at the
 ///      sentinel and matches any module whose `supportsInterface(IBravaSafeModule.interfaceId)`
 ///      returns true. Reverts on zero or more than one match — the Safe owner resolves both states

--- a/contracts/libraries/EIP712TypedDataLib.sol
+++ b/contracts/libraries/EIP712TypedDataLib.sol
@@ -1,24 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.28;
 
+import {IAuthRegistry} from "../interfaces/IAuthRegistry.sol";
 import {IEip712TypedDataSafeModule} from "../interfaces/IEip712TypedDataSafeModule.sol";
 
 /// @title EIP712TypedDataLib
-/// @notice External library for EIP-712 type strings, type hashes, and hashing helpers to keep module bytecode small
+/// @notice External library for EIP-712 type strings, type hashes, and hashing helpers shared by
+///         the bundle-executing module (Bundle) and the AuthRegistry (AuthBundle).
 library EIP712TypedDataLib {
     // EIP-712 type strings (referenced types appended in alphabetical order per EIP-712 spec)
     string private constant ACTION_DEFINITION_TYPE = "ActionDefinition(string protocolName,uint8 actionType)";
     string private constant MANAGER_RESTRICTION_TYPE = "ManagerRestriction(address manager,uint8[] allowedActionTypes)";
     string private constant AUTH_UPDATE_TYPE = "AuthUpdate(uint256 newVersion,address[] newManagers,address[] newCoSigners,uint256 managerCoSignThreshold,ManagerRestriction[] managerRestrictions)ManagerRestriction(address manager,uint8[] allowedActionTypes)";
+    string private constant AUTH_BUNDLE_TYPE = "AuthBundle(uint256 expiry,AuthUpdate authUpdate)AuthUpdate(uint256 newVersion,address[] newManagers,address[] newCoSigners,uint256 managerCoSignThreshold,ManagerRestriction[] managerRestrictions)ManagerRestriction(address manager,uint8[] allowedActionTypes)";
     string private constant SEQUENCE_TYPE = "Sequence(string name,ActionDefinition[] actions,bytes4[] actionIds,bytes[] callData)ActionDefinition(string protocolName,uint8 actionType)";
     string private constant CHAIN_SEQUENCE_TYPE = "ChainSequence(uint256 chainId,uint256 sequenceNonce,bool deploySafe,bool enableGasRefund,uint256 maxRefundAmount,uint8 refundRecipient,Sequence sequence)ActionDefinition(string protocolName,uint8 actionType)Sequence(string name,ActionDefinition[] actions,bytes4[] actionIds,bytes[] callData)";
-    string private constant BUNDLE_TYPE = "Bundle(uint256 expiry,ChainSequence[] sequences,AuthUpdate authUpdate)ActionDefinition(string protocolName,uint8 actionType)AuthUpdate(uint256 newVersion,address[] newManagers,address[] newCoSigners,uint256 managerCoSignThreshold,ManagerRestriction[] managerRestrictions)ChainSequence(uint256 chainId,uint256 sequenceNonce,bool deploySafe,bool enableGasRefund,uint256 maxRefundAmount,uint8 refundRecipient,Sequence sequence)ManagerRestriction(address manager,uint8[] allowedActionTypes)Sequence(string name,ActionDefinition[] actions,bytes4[] actionIds,bytes[] callData)";
+    string private constant BUNDLE_TYPE = "Bundle(uint256 expiry,ChainSequence[] sequences)ActionDefinition(string protocolName,uint8 actionType)ChainSequence(uint256 chainId,uint256 sequenceNonce,bool deploySafe,bool enableGasRefund,uint256 maxRefundAmount,uint8 refundRecipient,Sequence sequence)Sequence(string name,ActionDefinition[] actions,bytes4[] actionIds,bytes[] callData)";
     string private constant DOMAIN_TYPE = "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)";
 
     // Precomputed type hashes
     bytes32 private constant ACTION_DEFINITION_TYPEHASH = keccak256(abi.encodePacked(ACTION_DEFINITION_TYPE));
     bytes32 private constant MANAGER_RESTRICTION_TYPEHASH = keccak256(abi.encodePacked(MANAGER_RESTRICTION_TYPE));
     bytes32 private constant AUTH_UPDATE_TYPEHASH = keccak256(abi.encodePacked(AUTH_UPDATE_TYPE));
+    bytes32 private constant AUTH_BUNDLE_TYPEHASH = keccak256(abi.encodePacked(AUTH_BUNDLE_TYPE));
     bytes32 private constant SEQUENCE_TYPEHASH = keccak256(abi.encodePacked(SEQUENCE_TYPE));
     bytes32 private constant CHAIN_SEQUENCE_TYPEHASH = keccak256(abi.encodePacked(CHAIN_SEQUENCE_TYPE));
     bytes32 private constant BUNDLE_TYPEHASH = keccak256(abi.encodePacked(BUNDLE_TYPE));
@@ -70,7 +74,7 @@ library EIP712TypedDataLib {
         ));
     }
 
-    function hashManagerRestriction(IEip712TypedDataSafeModule.ManagerRestriction memory restriction) public pure returns (bytes32) {
+    function hashManagerRestriction(IAuthRegistry.ManagerRestriction memory restriction) public pure returns (bytes32) {
         bytes32[] memory actionTypeWords = new bytes32[](restriction.allowedActionTypes.length);
         for (uint256 i = 0; i < restriction.allowedActionTypes.length; i++) {
             actionTypeWords[i] = bytes32(uint256(restriction.allowedActionTypes[i]));
@@ -82,7 +86,7 @@ library EIP712TypedDataLib {
         ));
     }
 
-    function hashAuthUpdate(IEip712TypedDataSafeModule.AuthUpdate memory update) public pure returns (bytes32) {
+    function hashAuthUpdate(IAuthRegistry.AuthUpdate memory update) public pure returns (bytes32) {
         bytes32[] memory managerWords = new bytes32[](update.newManagers.length);
         for (uint256 i = 0; i < update.newManagers.length; i++) {
             managerWords[i] = bytes32(uint256(uint160(update.newManagers[i])));
@@ -105,6 +109,14 @@ library EIP712TypedDataLib {
         ));
     }
 
+    function hashAuthBundle(IAuthRegistry.AuthBundle memory authBundle) public pure returns (bytes32) {
+        return keccak256(abi.encode(
+            AUTH_BUNDLE_TYPEHASH,
+            authBundle.expiry,
+            hashAuthUpdate(authBundle.authUpdate)
+        ));
+    }
+
     function hashBundle(IEip712TypedDataSafeModule.Bundle memory bundle) public pure returns (bytes32) {
         bytes32[] memory chainSequenceHashes = new bytes32[](bundle.sequences.length);
         for (uint256 i = 0; i < bundle.sequences.length; i++) {
@@ -114,15 +126,15 @@ library EIP712TypedDataLib {
         return keccak256(abi.encode(
             BUNDLE_TYPEHASH,
             bundle.expiry,
-            keccak256(abi.encodePacked(chainSequenceHashes)),
-            hashAuthUpdate(bundle.authUpdate)
+            keccak256(abi.encodePacked(chainSequenceHashes))
         ));
     }
 
-    /// @dev Uses a fixed chainId of 1 so that cross-chain bundles produce a single canonical
+    /// @dev Uses a fixed chainId of 1 so that cross-chain payloads produce a single canonical
     ///      digest regardless of which chain verifies the signature. Replay protection is
-    ///      provided by the per-Safe `sequenceNonce` (incremented per-chain on execution) and
-    ///      the `verifyingContract` (the deterministic CREATE2 Safe address).
+    ///      provided by the per-Safe `sequenceNonce` (Bundle) or the registry's version
+    ///      monotonicity (AuthBundle), together with the `verifyingContract` (the deterministic
+    ///      CREATE2 Safe address).
     function domainSeparator(string memory name, string memory version, address verifyingContract) public pure returns (bytes32) {
         return keccak256(abi.encode(
             DOMAIN_TYPEHASH,
@@ -142,5 +154,15 @@ library EIP712TypedDataLib {
     ) public pure returns (bytes32) {
         bytes32 ds = domainSeparator(name, version, verifyingContract);
         return keccak256(abi.encodePacked("\x19\x01", ds, hashBundle(bundle)));
+    }
+
+    function hashAuthBundleForSigning(
+        string memory name,
+        string memory version,
+        address verifyingContract,
+        IAuthRegistry.AuthBundle calldata authBundle
+    ) public pure returns (bytes32) {
+        bytes32 ds = domainSeparator(name, version, verifyingContract);
+        return keccak256(abi.encodePacked("\x19\x01", ds, hashAuthBundle(authBundle)));
     }
 }


### PR DESCRIPTION
Verbatim mirror of brava-contracts-private `main` @ a1907f3, preserving commit hashes.

Merge with **Create a merge commit** only — squash/rebase merges rewrite the commit hashes cited in the audit report.